### PR TITLE
remove htmlencode function

### DIFF
--- a/frontend/src/pages/audits/edit/findings/add/add.html
+++ b/frontend/src/pages/audits/edit/findings/add/add.html
@@ -106,7 +106,7 @@
                 </q-tr>
                 <q-tr v-show="props.expand" :props="props">
                     <q-td colspan="100%" class="bg-grey-4">
-                        <div class="editor__content" style="white-space: initial" v-html="htmlEncode(props.row.detail.description)"></div>
+                        <div class="editor__content" style="white-space: initial" v-html="props.row.detail.description"></div>
                     </q-td>
                 </q-tr>
             </template>


### PR DESCRIPTION
should remove "htmlEncode" function here.

Reason: end-user can not access some pages that contain HTML code in the description.

Demo: https://drive.google.com/file/d/1EsjLqz_szuiUfkRxBgqHqajSwB-7dIEy/view?usp=sharing

<img width="1587" alt="image" src="https://user-images.githubusercontent.com/58721688/96972897-551db580-1541-11eb-85b9-90406dcc1c74.png">
