### PR TITLE
Multi ext reports

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -11,7 +11,7 @@ var _ = require('lodash');
 
 // Generate document with docxtemplater
 function generateDoc(audit) {
-    var templatePath = `${__basedir}/../report-templates/${audit.template.name}.docx`
+    var templatePath = `${__basedir}/../report-templates/${audit.template.name}.${audit.template.ext}`
     var preppedAudit = prepAuditData(audit)
     var content = fs.readFileSync(templatePath, "binary");
 

--- a/backend/src/models/template.js
+++ b/backend/src/models/template.js
@@ -16,6 +16,7 @@ TemplateSchema.statics.getAll = () => {
     return new Promise((resolve, reject) => {
         var query = Template.find();
         query.select('name')
+        query.select('ext')
         query.exec()
         .then((rows) => {
             resolve(rows);
@@ -31,6 +32,7 @@ TemplateSchema.statics.getOne = (templateId) => {
     return new Promise((resolve, reject) => {
         var query = Template.findById(templateId);
         query.select('name')
+        query.select('ext')
         query.exec()
         .then((rows) => {
             resolve(rows);

--- a/backend/src/models/template.js
+++ b/backend/src/models/template.js
@@ -2,7 +2,8 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var TemplateSchema = new Schema({
-    name:      {type: String, required: true, unique: true}
+    name:      {type: String, required: true, unique: true},
+    ext:      {type: String, required: true, unique: false}
 
 }, {timestamps: true});
 

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -282,7 +282,7 @@ module.exports = function(app, io) {
         Audit.getAudit(acl.isAdmin(req.decodedToken.role, 'audits:update'), req.params.auditId, req.decodedToken.id)
         .then( audit => {
             var reportDoc = reportGenerator.generateDoc(audit);
-            Response.SendFile(res, `${audit.name}.docx`, reportDoc);
+            Response.SendFile(res, `${audit.name}.${audit.template.ext}`, reportDoc);
         })
         .catch(err => Response.Internal(res, err));
     });

--- a/backend/src/routes/template.js
+++ b/backend/src/routes/template.js
@@ -29,10 +29,18 @@ module.exports = function(app) {
         // Required parameters
         template.name = req.body.name;
 
+        var filename = req.body.filename;
+        template.ext = filename.includes(".") ? filename.split(".").slice(-1)[0] : filename
+        
+        if (!utils.validFilename(template.ext)) {
+            Response.BadParameters(res, 'Bad extension format');
+            return;
+        }
+
         Template.create(template)
         .then(data => {
             var fileBuffer = Buffer.from(req.body.file, 'base64');
-            fs.writeFileSync(`${__basedir}/../report-templates/${template.name}.docx`, fileBuffer);
+            fs.writeFileSync(`${__basedir}/../report-templates/${template.name}.${template.ext}`, fileBuffer);
             Response.Created(res, 'Template created successfully');
         })
         .catch(err => Response.Internal(res, err))

--- a/backend/src/routes/template.js
+++ b/backend/src/routes/template.js
@@ -101,8 +101,8 @@ module.exports = function(app) {
      app.get("/api/templates/download/:templateId", acl.hasPermission('templates:read'), function(req, res) {
         Template.getOne(req.params.templateId)
         .then(data => {
-            var file = `${__basedir}/../report-templates/${data.name}.docx`
-            res.download(file, `${data.name}.docx`)
+            var file = `${__basedir}/../report-templates/${data.name}.${audit.template.ext}`
+            res.download(file, `${data.name}.${audit.template.ext}`)
         })
         .catch(err => Response.Internal(res, err))
     })

--- a/backend/tests/template.test.js
+++ b/backend/tests/template.test.js
@@ -22,7 +22,7 @@ module.exports = function(request) {
       })
 
       it('Create 2 templates', async done => {
-        var template = {name: "Template 1", file: "VGVzdCB0ZW1wbGF0ZQ=="}
+        var template = {name: "Template 1", filename: "File.docx", file: "VGVzdCB0ZW1wbGF0ZQ=="}
         var response = await request.post('/api/templates', template, options)
         expect(response.status).toBe(201)
 
@@ -41,7 +41,7 @@ module.exports = function(request) {
       })
 
       it('Should not create template with existing name', async done => {
-        var template = {name: "Template 1", file: "VGVzdCB0ZW1wbGF0ZQ=="}
+        var template = {name: "Template 1", filename: "File.docx", file: "VGVzdCB0ZW1wbGF0ZQ=="}
         var response = await request.post('/api/templates', template, options)
 
         expect(response.status).toBe(422)

--- a/frontend/src/pages/datas/templates/templates.html
+++ b/frontend/src/pages/datas/templates/templates.html
@@ -86,7 +86,7 @@
                         <q-uploader
                         class="col-md-12"
                         label='File *'
-                        accept='.doc,.docx,.ppt,.pptx'
+                        accept='.doc,.docx,.docm,.ppt,.pptx'
                         hide-upload-btn
                         @added="handleFile"
                         />
@@ -132,7 +132,7 @@
                         <q-uploader
                         class="col-md-12"
                         label='File *'
-                        accept='.doc,.docx,.ppt,.pptx'
+                        accept='.doc,.docx,.docm,.ppt,.pptx'
                         hide-upload-btn
                         @added="handleFile"
                         />

--- a/frontend/src/pages/datas/templates/templates.js
+++ b/frontend/src/pages/datas/templates/templates.js
@@ -188,6 +188,7 @@ export default {
                 this.currentTemplate.file = fileReader.result.split(",")[1];
             }
 
+            this.currentTemplate.filename = file.name
             fileReader.readAsDataURL(file);
         }
     }

--- a/frontend/src/pages/datas/templates/templates.js
+++ b/frontend/src/pages/datas/templates/templates.js
@@ -58,7 +58,7 @@ export default {
         downloadTemplate: function(row) {
             TemplateService.downloadTemplate(row._id)
             .then((data) => {
-                status = exportFile(`${row.name}.docx`, data.data, {type: "application/octet-stream"})
+                status = exportFile(`${row.name}.${row.ext}`, data.data, {type: "application/octet-stream"})
                 if (!status)
                     throw (status)
             })


### PR DESCRIPTION
I needed docm audit reports so I implemented the following feature.

-  Docm has been added to extension whitelist
-  Template is no longer saved with docx extension, but with the original file extension (doc, docx, docm, ppt or pptx)
-  Audit reports are now proposed with the original template extension (doc, docx, docm, ppt or pptx)
