### PR TITLE
implemented resolution field

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -30,6 +30,7 @@ require('./models/vulnerability-update');
 require('./models/language');
 require('./models/audit-type');
 require('./models/vulnerability-type');
+require('./models/resolution');
 require('./models/vulnerability-category');
 require('./models/custom-section');
 

--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -103,6 +103,8 @@ var roles = {
             'audit-types:read',
             // Vulnerability Types
             'vulnerability-types:read',
+            // Resolution statuses
+            'resolution:read',
             // Vulnerability Categories
             'vulnerability-categories:read',
             // Sections Data

--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -315,7 +315,8 @@ function prepAuditData(data) {
             poc: splitHTMLParagraphs(finding.poc),
             affected: finding.scope || "",
             status: finding.status || "",
-            category: finding.category || ""
+            category: finding.category || "",
+            resolution: finding.resolution || "undefined"
         }
         if (finding.customFields) {
             finding.customFields.forEach(field => {
@@ -339,6 +340,7 @@ function prepAuditData(data) {
             text: splitHTMLParagraphs(section.text) 
         }
     })
+
     return result
 }
 

--- a/backend/src/models/audit.js
+++ b/backend/src/models/audit.js
@@ -31,6 +31,7 @@ var Finding = {
     scope:                  String,
     status:                 {type: Number, enum: [0,1], default: 1}, // 0: done, 1: redacting
     category:               String,
+    resolution:             String,
     customFields:           [customField]
 }
 
@@ -283,7 +284,7 @@ AuditSchema.statics.getFindings = (isAdmin, auditId, userId) => {
         var query = Audit.findById(auditId)
         if (!isAdmin)
             query.or([{creator: userId}, {collaborators: userId}])
-        query.select('-_id findings._id findings.title findings.cvssSeverity findings.cvssScore');
+        query.select('-_id findings._id findings.title findings.cvssSeverity findings.cvssScore findings.resolution');
         query.sort({'findings.cvssScore': -1})
         query.exec()
         .then((row) => {

--- a/backend/src/models/resolution.js
+++ b/backend/src/models/resolution.js
@@ -1,0 +1,84 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var ResolutionSchema = new Schema({
+  name: String,
+  locale: String
+}, { timestamps: true });
+
+ResolutionSchema.index({ "name": 1, "locale": 1 }, { name: "unique_name_locale", unique: true })
+
+/*
+*** Statics ***
+*/
+
+// Get all resolutions
+ResolutionSchema.statics.getAll = () => {
+  return new Promise((resolve, reject) => {
+    var query = Resolution.find();
+    query.select('-_id name locale')
+    query.exec()
+      .then((rows) => {
+        resolve(rows);
+      })
+      .catch((err) => {
+        reject(err);
+      })
+  });
+}
+
+// Create resolution
+ResolutionSchema.statics.create = (resolution) => {
+  return new Promise((resolve, reject) => {
+    var query = new Resolution(resolution);
+    query.save()
+      .then((row) => {
+        resolve(row);
+      })
+      .catch((err) => {
+        if (err.code === 11000)
+          reject({ fn: 'BadParameters', message: 'Resolution already exists' });
+        else
+          reject(err);
+      })
+  })
+}
+
+// Update resolution
+ResolutionSchema.statics.updateAll = (resolutions) => {
+  return new Promise((resolve, reject) => {
+    Resolution.deleteMany()
+      .then((row) => {
+        Resolution.insertMany(resolutions)
+      })
+      .then((row) => {
+        resolve("Resolutions updated successfully")
+      })
+      .catch((err) => {
+        reject(err);
+      })
+  })
+}
+
+// Delete resolution
+ResolutionSchema.statics.delete = (name) => {
+  return new Promise((resolve, reject) => {
+    Resolution.deleteOne({ name: name })
+      .then((res) => {
+        if (res.deletedCount === 1)
+          resolve('Resolution deleted');
+        else
+          reject({ fn: 'NotFound', message: 'Resolution not found' });
+      })
+      .catch((err) => {
+        reject(err);
+      })
+  });
+}
+
+/*
+*** Methods ***
+*/
+
+var Resolution = mongoose.model('Resolution', ResolutionSchema);
+module.exports = Resolution;

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -134,6 +134,7 @@ module.exports = function(app, io) {
         if (req.body.scope) finding.scope = req.body.scope;
         if (req.body.status !== undefined) finding.status = req.body.status;
         if (req.body.category) finding.category = req.body.category
+        if (req.body.resolution) finding.resolution = req.body.resolution
         if (req.body.customFields) finding.customFields = req.body.customFields
 
         Audit.createFinding(acl.isAdmin(req.decodedToken.role, 'audits:update'), req.params.auditId, req.decodedToken.id, finding)
@@ -177,6 +178,7 @@ module.exports = function(app, io) {
         if (req.body.scope) finding.scope = req.body.scope;
         if (req.body.status !== undefined) finding.status = req.body.status;
         if (req.body.category) finding.category = req.body.category
+        if (req.body.resolution) finding.resolution = req.body.resolution
         if (req.body.customFields) finding.customFields = req.body.customFields
 
         Audit.updateFinding(acl.isAdmin(req.decodedToken.role, 'audits:update'), req.params.auditId, req.decodedToken.id, req.params.findingId, finding)

--- a/docs/docxtemplate.md
+++ b/docs/docxtemplate.md
@@ -196,6 +196,7 @@ List of findings. Array of Objects:
 * **findings[i].affected** (HTML without images)
 * **findings[i].status** (Number 0:done, 1:redacting)
 * **findings[i].category**
+* **findings[i].resolution**
 
 Additional fields specific to the Category will also be added to the findings Array. The key will be lowercase + strip sapces of the label.  
 Eg. if Category label is `Aggravating Factors` it will be added to the array as `findings[i].aggravatingfactors`.

--- a/frontend/src/pages/audits/edit/findings/edit/edit.html
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.html
@@ -130,7 +130,7 @@
                     <q-select
                     label="Remediation Difficulty"
                     stack-label
-                    class="col-md-6"
+                    class="col-md-4"
                     v-model="finding.remediationComplexity"
                     :options="[{label: 'Easy', value: 1},{label: 'Medium', value: 2},{label: 'Complex', value: 3}]"
                     map-options
@@ -140,10 +140,21 @@
                     <q-select
                     label="Priority"
                     stack-label
-                    class="col-md-6"
+                    class="col-md-4"
                     v-model="finding.priority"
                     :options="[{label: 'Low', value: 1},{label: 'Medium', value: 2},{label: 'High', value: 3},{label: 'Urgent', value: 4}]"
                     map-options
+                    emit-value
+                    options-sanitize
+                    />
+                    <q-select
+                    label="Resolution"
+                    stack-label
+                    class="col-md-4"
+                    v-model="finding.resolution"
+                    :options="resolutionsLang"
+                    option-value="name" 
+                    option-label="name" 
                     emit-value
                     options-sanitize
                     />

--- a/frontend/src/pages/audits/edit/findings/edit/edit.js
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.js
@@ -15,6 +15,7 @@ export default {
             findingOrig: {},
             selectedTab: "definition",
             vulnTypes: [],
+            resolutions: [],
             referencesString: ""
         }
     },
@@ -28,8 +29,10 @@ export default {
     mounted: function() {
         this.auditId = this.$route.params.auditId;
         this.findingId = this.$route.params.findingId;
+        this.getResolutions();
         this.getFinding();
         this.getVulnTypes();
+        
 
         this.$socket.emit('menu', {menu: 'editFinding', finding: this.findingId, room: this.auditId});
 
@@ -78,6 +81,10 @@ export default {
             return this.vulnTypes.filter(type => type.locale === this.$parent.audit.language);
         },
 
+        resolutionsLang: function() {
+            return this.resolutions.filter(r => r.locale === this.$parent.audit.language);
+        },
+
         screenshotsSize: function() {
             return ((JSON.stringify(this.uploadedImages).length) / 1024).toFixed(2)
         }
@@ -105,6 +112,17 @@ export default {
             })
         },
 
+        // Get resolutions
+        getResolutions: function () {
+            DataService.getResolutions()
+                .then((data) => {
+                    this.resolutions = data.data.datas;
+                })
+                .catch((err) => {
+                    console.log(err)
+                })
+        },
+
         // Get Finding
         getFinding: function() {
             AuditService.getFinding(this.auditId, this.findingId)
@@ -117,7 +135,8 @@ export default {
                 if (this.finding.references && this.finding.references.length > 0)
                     this.referencesString = this.finding.references.join('\n')
                 
-                this.findingOrig = this.$_.cloneDeep(this.finding);                
+                this.findingOrig = this.$_.cloneDeep(this.finding);   
+
             })
             .catch((err) => {
                 if (err.response.status === 403)

--- a/frontend/src/pages/datas/custom/custom.html
+++ b/frontend/src/pages/datas/custom/custom.html
@@ -211,6 +211,107 @@
             </q-card>
         </div>
 
+        <!-- vulnerability Resolutions -->
+        <div class="col-md-10 offset-md-1 q-mt-md">
+            <q-card>
+                <q-card-section class="q-py-xs bg-blue-grey-5 text-white">
+                    <div class="text-h6">Vulnerability Resolutions</div>
+                </q-card-section>
+                <q-separator />
+        
+                <q-card-section>
+                    <div class="text-grey-8">Create a resolution status to be used in the audit reports (Ex: 'Open', 'Solved', 'Won't Fix')</div>
+                </q-card-section>
+                <q-card-section v-if="languages.length > 0" class="row">
+                    <div class="col-md-6">
+                        <q-item class="row">
+                            <q-item-section class="col-md-4">
+                                <q-select 
+                                v-model="newResolution.locale" 
+                                label="Language" 
+                                :options="languages"
+                                option-value="locale" 
+                                option-label="language" 
+                                emit-value 
+                                map-options 
+                                options-sanitize 
+                                />
+                            </q-item-section>
+                        </q-item>
+                        <q-item>
+                            <q-item-section>
+                                <q-input 
+                                label="Name" 
+                                v-model="newResolution.name" 
+                                clearable 
+                                :error="!!errors.resolution"
+                                :error-message="errors.resolution" 
+                                @keyup.enter="createResolution" 
+                                />
+                            </q-item-section>
+                            <q-item-section side>
+                                <q-btn color="secondary" unelevated label="+" size="md" @click="createResolution" />
+                            </q-item-section>
+                        </q-item>
+                    </div>
+        
+                    <div v-if="!editResolution" class="col-md-6">
+                        <q-card flat bordered v-if="resolutions.length > 0">
+                            <q-toolbar>
+                                <div class="text-grey-8">List of Resolutions</div>
+                                <q-space />
+                                <q-btn flat color="primary" icon="fa fa-edit"
+                                    @click="editResolution = true; editResolutions = $_.cloneDeep(resolutions)">
+                                    <q-tooltip anchor="bottom middle" self="center left" :delay="500" content-class="text-bold">
+                                        Edit</q-tooltip>
+                                </q-btn>
+                            </q-toolbar>
+                            <q-separator />
+                            <q-item v-for="r of resolutions" :key="r.name"
+                                v-if="r.locale === newResolution.locale">
+                                <q-item-section>
+                                    <q-input label="Name" v-model="r.name" readonly />
+                                </q-item-section>
+                            </q-item>
+                        </q-card>
+                    </div>
+                    <div v-else class="col-md-6">
+                        <q-card flat bordered>
+                            <q-toolbar>
+                                <div class="text-grey-8">Edit Resolution</div>
+                            </q-toolbar>
+                            <q-separator />
+                            <q-card-section>
+                                <draggable v-model="editResolutions" handle=".handle" ghost-class="drag-ghost">
+                                    <q-item v-for="(r,index) of editResolutions" :key="index"
+                                        v-if="r.locale === r.locale">
+                                        <q-item-section avatar>
+                                            <q-icon name="mdi-arrow-split-horizontal" class="cursor-pointer handle"
+                                                color="grey" />
+                                        </q-item-section>
+                                        <q-item-section>
+                                            <q-input label="Name" v-model="r.name" />
+                                        </q-item-section>
+                                        <q-item-section side>
+                                            <q-btn color="red" unelevated label="x" size="md" class="q-mt-md"
+                                                @click="removeResolution(r)" />
+                                        </q-item-section>
+                                    </q-item>
+                                </draggable>
+                            </q-card-section>
+                            <q-card-actions align="right" class="q-mr-lg">
+                                <q-btn color="primary" outline @click="editResolutions = false">Cancel</q-btn>
+                                <q-btn color="secondary" unelevated @click="updateResolutions">Save</q-btn>
+                            </q-card-actions>
+                        </q-card>
+                    </div>
+                </q-card-section>
+                <q-card-section v-else>
+                    <p>Please create at least one Language</p>
+                </q-card-section>
+            </q-card>
+        </div>
+
         <!-- VULNERABILITY TYPES -->
         <div class="col-md-10 offset-md-1 q-mt-md">
             <q-card>

--- a/frontend/src/pages/datas/custom/custom.js
+++ b/frontend/src/pages/datas/custom/custom.js
@@ -22,6 +22,11 @@ export default {
             editVulnTypes: [],
             editVulnType: false,
 
+            resolutions: [],
+            newResolution: { name: "", locale: "" },
+            editResolutions: [],
+            editResolution: false,
+
             vulnCategories: [],
             newVulnCat: {name: "", fields: []},
             newVulnCatField: {label: "", fieldType: ""},
@@ -33,7 +38,7 @@ export default {
             editSections: [],
             editSection: false,
 
-            errors: {locale: '', language: '', auditType: '', vulnType: '', vulnCat: '', vulnCatField: '', sectionField: '', sectionName: ''}
+            errors: {locale: '', language: '', auditType: '', resolution: '', vulnType: '', vulnCat: '', vulnCatField: '', sectionField: '', sectionName: ''}
         }
     },
 
@@ -45,6 +50,7 @@ export default {
     mounted: function() {
         this.getLanguages();
         this.getAuditTypes();
+        this.getResolutions();
         this.getVulnerabilityTypes();
         this.getVulnerabilityCategories();
         this.getSections();
@@ -62,6 +68,7 @@ export default {
                     this.newAuditType.locale = this.languages[0].locale;
                     this.newVulnType.locale = this.languages[0].locale;
                     this.newSection.locale = this.languages[0].locale;
+                    this.newResolution.locale = this.languages[0].locale;
                 }
             })
             .catch((err) => {
@@ -130,74 +137,146 @@ export default {
             this.editLanguages = this.editLanguages.filter(e => e.locale !== locale)
         },
 
-/* ===== AUDIT TYPES ===== */
+/* ===== RESOLUTION ===== */
 
-        // Get available audit types
-        getAuditTypes: function() {
-            DataService.getAuditTypes()
+        // Get available resolutions
+        getResolutions: function() {
+            DataService.getResolutions()
             .then((data) => {
-                this.auditTypes = data.data.datas;
+                this.resolutions = data.data.datas;
             })
             .catch((err) => {
                 console.log(err)
             })
         },
 
+        // Create resolution 
+        createResolution: function() {
+            this.cleanErrors();
+            if (!this.newResolution.name)
+                this.errors.resolution = "Name required";
+            
+            if (this.errors.resolution)
+                return;
+
+            DataService.createResolution(this.newResolution)
+            .then((data) => {
+                this.newResolution.name = "";
+                this.getResolutions();
+                Notify.create({
+                    message: 'Resolution created successfully',
+                    color: 'positive',
+                    textColor:'white',
+                    position: 'top-right'
+                })
+            })
+            .catch((err) => {
+                Notify.create({
+                    message: err.response.data.datas,
+                    color: 'negative',
+                    textColor: 'white',
+                    position: 'top-right'
+                })
+            })
+        },
+
+        // Update Resolutions
+        updateResolutions: function() {
+            DataService.updateResolutions(this.editResolutions)
+            .then((data) => {
+                this.getResolutions()
+                this.editResolution = false
+                Notify.create({
+                    message: 'Resolution Type updated successfully',
+                    color: 'positive',
+                    textColor:'white',
+                    position: 'top-right'
+                })
+            })
+            .catch((err) => {
+                Notify.create({
+                    message: err.response.data.datas,
+                    color: 'negative',
+                    textColor: 'white',
+                    position: 'top-right'
+                })
+            })
+        },
+
+        // Remove Resolution
+        removeResolution: function (resolution) {
+            console.log(resolution)
+            this.editResolutions = this.editResolutions.filter(e => e.name !== resolution.name || e.locale !== resolution.locale)
+        },
+
+        /* ===== AUDIT TYPES ===== */
+
+        // Get available audit types
+        getAuditTypes: function () {
+            DataService.getAuditTypes()
+                .then((data) => {
+                    this.auditTypes = data.data.datas;
+                })
+                .catch((err) => {
+                    console.log(err)
+                })
+        },
+
         // Create Audit type
-        createAuditType: function() {
+        createAuditType: function () {
             this.cleanErrors();
             if (!this.newAuditType.name)
                 this.errors.auditType = "Name required";
-            
+
             if (this.errors.auditType)
                 return;
 
             DataService.createAuditType(this.newAuditType)
-            .then((data) => {
-                this.newAuditType.name = "";
-                this.getAuditTypes();
-                Notify.create({
-                    message: 'Audit type created successfully',
-                    color: 'positive',
-                    textColor:'white',
-                    position: 'top-right'
+                .then((data) => {
+                    this.newAuditType.name = "";
+                    this.getAuditTypes();
+                    Notify.create({
+                        message: 'Audit type created successfully',
+                        color: 'positive',
+                        textColor: 'white',
+                        position: 'top-right'
+                    })
                 })
-            })
-            .catch((err) => {
-                Notify.create({
-                    message: err.response.data.datas,
-                    color: 'negative',
-                    textColor: 'white',
-                    position: 'top-right'
+                .catch((err) => {
+                    Notify.create({
+                        message: err.response.data.datas,
+                        color: 'negative',
+                        textColor: 'white',
+                        position: 'top-right'
+                    })
                 })
-            })
         },
 
         // Update Audit Types
-        updateAuditTypes: function() {
+        updateAuditTypes: function () {
             DataService.updateAuditTypes(this.editAuditTypes)
-            .then((data) => {
-                this.getAuditTypes()
-                this.editAuditType = false
-                Notify.create({
-                    message: 'Audit Types updated successfully',
-                    color: 'positive',
-                    textColor:'white',
-                    position: 'top-right'
+                .then((data) => {
+                    this.getAuditTypes()
+                    this.editAuditType = false
+                    Notify.create({
+                        message: 'Audit Types updated successfully',
+                        color: 'positive',
+                        textColor: 'white',
+                        position: 'top-right'
+                    })
                 })
-            })
-            .catch((err) => {
-                Notify.create({
-                    message: err.response.data.datas,
-                    color: 'negative',
-                    textColor: 'white',
-                    position: 'top-right'
+                .catch((err) => {
+                    Notify.create({
+                        message: err.response.data.datas,
+                        color: 'negative',
+                        textColor: 'white',
+                        position: 'top-right'
+                    })
                 })
-            })
         },
 
         // Remove Audit Type
-        removeAuditType: function(auditType) {
+        removeAuditType: function (auditType) {
             this.editAuditTypes = this.editAuditTypes.filter(e => e.name !== auditType.name || e.locale !== auditType.locale)
         },
 

--- a/frontend/src/services/data.js
+++ b/frontend/src/services/data.js
@@ -49,6 +49,22 @@ export default {
         return Vue.prototype.$axios.put(`data/vulnerability-types`, vulnTypes)
     },
 
+    getResolutions: function () {
+        return Vue.prototype.$axios.get(`data/resolutions`)
+    },
+
+    createResolution: function (resolutionStatus) {
+        return Vue.prototype.$axios.post(`data/resolutions`, resolutionStatus)
+    },
+
+    deleteResolution: function (name) {
+        return Vue.prototype.$axios.delete(`data/rresolutions/${name}`)
+    },
+
+    updateResolutions: function (resolutionStatuses) {
+        return Vue.prototype.$axios.put(`data/resolutions`, resolutionStatuses)
+    },
+
     getVulnerabilityCategories: function() {
         return Vue.prototype.$axios.get(`data/vulnerability-categories`)
     },


### PR DESCRIPTION
Created a new customisable field called 'resolution' which is intended to create resolutions status for each finding.
This can then be set per finding in the audit view, and there's also the placeholder {resolution} to add in the generated report.

This is helpful when you are re-evaluating projects, where you can use the existing Audit report to update status, as well as add new findings if needed.

![image](https://user-images.githubusercontent.com/5262312/97616449-7cc6bf00-1a14-11eb-8b5f-92a15a53d054.png)
![image](https://user-images.githubusercontent.com/5262312/97616644-b8618900-1a14-11eb-9297-aa0ca12cdf51.png)
