### PR TITLE
Vuln id prefix

### DIFF
--- a/backend/src/lib/custom-generator.js
+++ b/backend/src/lib/custom-generator.js
@@ -54,6 +54,7 @@ expressions.filters.convertDateFR = function(input, s) {
 }
 
 // Convert identifier prefix to a user defined prefix: {identifier | changeID: 'PRJ-'}
+// TODO: REMOVE ME
 expressions.filters.changeID = function (input, prefix) {
     return input.replace("IDX-", prefix);
 }

--- a/backend/src/lib/custom-generator.js
+++ b/backend/src/lib/custom-generator.js
@@ -53,11 +53,5 @@ expressions.filters.convertDateFR = function(input, s) {
     }
 }
 
-// Convert identifier prefix to a user defined prefix: {identifier | changeID: 'PRJ-'}
-// TODO: REMOVE ME
-expressions.filters.changeID = function (input, prefix) {
-    return input.replace("IDX-", prefix);
-}
-
 exports.expressions = expressions
 

--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -317,7 +317,7 @@ function prepAuditData(data) {
             affected: finding.scope || "",
             status: finding.status || "",
             category: finding.category || "",
-            identifier: data.idPrefix + lPad(finding.identifier),
+            identifier: data.idPrefix + utils.lPad(finding.identifier),
             resolution: finding.resolution || "undefined"
         }
         if (finding.customFields) {

--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -317,7 +317,7 @@ function prepAuditData(data) {
             affected: finding.scope || "",
             status: finding.status || "",
             category: finding.category || "",
-            identifier: data.idPrefix + utils.lPad(finding.identifier)
+            identifier: data.idPrefix + utils.lPad((finding.identifier || 1 ) + (data.idStart || 1) - 1)
         }
         if (finding.customFields) {
             finding.customFields.forEach(field => {

--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -317,8 +317,7 @@ function prepAuditData(data) {
             affected: finding.scope || "",
             status: finding.status || "",
             category: finding.category || "",
-            identifier: data.idPrefix + utils.lPad(finding.identifier),
-            resolution: finding.resolution || "undefined"
+            identifier: data.idPrefix + utils.lPad(finding.identifier)
         }
         if (finding.customFields) {
             finding.customFields.forEach(field => {

--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -317,7 +317,8 @@ function prepAuditData(data) {
             affected: finding.scope || "",
             status: finding.status || "",
             category: finding.category || "",
-            identifier: "IDX-" + utils.lPad(finding.identifier)
+            identifier: data.idPrefix + lPad(finding.identifier),
+            resolution: finding.resolution || "undefined"
         }
         if (finding.customFields) {
             finding.customFields.forEach(field => {

--- a/backend/src/models/audit.js
+++ b/backend/src/models/audit.js
@@ -291,7 +291,6 @@ AuditSchema.statics.getLastFindingIdentifier = (auditId) => {
         query.sort({'findings.identifier': -1})
         query.exec()
         .then(row => {
-            console.log(row[0].findings.identifier)
             if (!row)
                 throw ({ fn: 'NotFound', message: 'Audit not found' })
             else if (row.length === 0 || !row[0].findings.identifier)

--- a/backend/src/models/audit.js
+++ b/backend/src/models/audit.js
@@ -62,6 +62,7 @@ var AuditSchema = new Schema({
     client:             {type: Schema.Types.ObjectId, ref: 'Client'},
     collaborators:      [{type: Schema.Types.ObjectId, ref: 'User'}],
     language:           {type: String, required: true},
+    idPrefix:           {type:String, default: "#"},
     scope:              [{_id: false, name: String, hosts: [Host]}],
     findings:           [Finding],
     template:           {type: Schema.Types.ObjectId, ref: 'Template'},
@@ -181,7 +182,7 @@ AuditSchema.statics.getGeneral = (isAdmin, auditId, userId) => {
             });
         query.populate('collaborators', 'username firstname lastname')
         query.populate('company')
-        query.select('id name auditType location date date_start date_end client collaborators language scope.name template')
+        query.select('id name auditType location date date_start date_end client collaborators language scope.name template idPrefix')
         query.exec()
         .then((row) => {
             if (!row)

--- a/backend/src/models/audit.js
+++ b/backend/src/models/audit.js
@@ -63,6 +63,7 @@ var AuditSchema = new Schema({
     collaborators:      [{type: Schema.Types.ObjectId, ref: 'User'}],
     language:           {type: String, required: true},
     idPrefix:           {type:String, default: "#"},
+    idStart:            {type: Number, default: 1},
     scope:              [{_id: false, name: String, hosts: [Host]}],
     findings:           [Finding],
     template:           {type: Schema.Types.ObjectId, ref: 'Template'},
@@ -182,7 +183,7 @@ AuditSchema.statics.getGeneral = (isAdmin, auditId, userId) => {
             });
         query.populate('collaborators', 'username firstname lastname')
         query.populate('company')
-        query.select('id name auditType location date date_start date_end client collaborators language scope.name template idPrefix')
+        query.select('id name auditType location date date_start date_end client collaborators language scope.name template idPrefix idStart')
         query.exec()
         .then((row) => {
             if (!row)

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -77,6 +77,7 @@ module.exports = function(app, io) {
         }
         if (req.body.collaborators) update.collaborators = req.body.collaborators;
         if (req.body.language) update.language = req.body.language;
+        if (req.body.idPrefix) update.idPrefix = req.body.idPrefix;
         if (req.body.scope && typeof(req.body.scope === "array")) {
             update.scope = req.body.scope.map(item => {return {name: item}});
         }

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -78,6 +78,15 @@ module.exports = function(app, io) {
         if (req.body.collaborators) update.collaborators = req.body.collaborators;
         if (req.body.language) update.language = req.body.language;
         if (req.body.idPrefix) update.idPrefix = req.body.idPrefix;
+        if (req.body.idStart) {
+            try{
+                update.idStart = parseInt(req.body.idStart);
+            }
+            catch(e){
+                update.idStart = 1;
+            }            
+        }
+
         if (req.body.scope && typeof(req.body.scope === "array")) {
             update.scope = req.body.scope.map(item => {return {name: item}});
         }

--- a/docs/docxtemplate.md
+++ b/docs/docxtemplate.md
@@ -199,8 +199,7 @@ List of findings. Array of Objects:
 * **findings[i].category**
 * **findings[i].identifier**
 
-Identifier consists on a sequential id for the reported vulnerability pre-pended with 'IDX-'. Ex: IDX-001.
-You can replace the prefix by using the filter ```changeID```
+Identifier consists on a sequential id prepended with the field "ID Prefix" defined in the audit general page. By default the prefix is '#'
 
 Additional fields specific to the Category will also be added to the findings Array. The key will be lowercase + strip sapces of the label.  
 Eg. if Category label is `Aggravating Factors` it will be added to the array as `findings[i].aggravatingfactors`.
@@ -208,7 +207,7 @@ Eg. if Category label is `Aggravating Factors` it will be added to the array as 
 > Use in template document
 >```
 List of Findings{#findings}
-{identifier | changeID: 'PROJ1-'}    {title}    {vulnType}
+{identifier}    {title}    {vulnType}
 >  
 Severity: {cvssSeverity}    Score: {cvssScore}
 Attack Vector: cvssObj.AV               Scope: cvssObj.S
@@ -276,13 +275,6 @@ There should now be abstractNum definition for each one.
 
 Filters allow to apply functions on Audit data values.
 
-### changeID
-
-Replaces the default identifier prefix (IDX-) by the supplied prefix
-> Use in template document
->```
-{identifier | changeID: 'PROJ1-'}
->```
 
 ### convertDate
 

--- a/frontend/src/pages/audits/edit/general/general.html
+++ b/frontend/src/pages/audits/edit/general/general.html
@@ -110,8 +110,12 @@
                         <q-select label="Template" v-model="audit.template" :options="templates" option-value="_id" option-label="name"
                             emit-value map-options options-sanitize />
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-md-3">
                         <q-input label="ID Prefix" v-model="audit.idPrefix" />
+                    </div>
+
+                    <div class="col-md-3">
+                        <q-input label="ID starts at" v-model="audit.idStart" />
                     </div>
                 </div>
             </q-card-section>

--- a/frontend/src/pages/audits/edit/general/general.html
+++ b/frontend/src/pages/audits/edit/general/general.html
@@ -105,16 +105,15 @@
                 map-options
                 options-sanitize
                 />
-                <q-select
-                label="Template"
-                v-model="audit.template"
-                :options="templates"
-                option-value="_id"
-                option-label="name"
-                emit-value
-                map-options
-                options-sanitize
-                /> 
+                <div class="row">
+                    <div class="col-md-6">
+                        <q-select label="Template" v-model="audit.template" :options="templates" option-value="_id" option-label="name"
+                            emit-value map-options options-sanitize />
+                    </div>
+                    <div class="col-md-6">
+                        <q-input label="ID Prefix" v-model="audit.idPrefix" />
+                    </div>
+                </div>
             </q-card-section>
         </q-card>
     </div>

--- a/frontend/src/pages/audits/edit/general/general.js
+++ b/frontend/src/pages/audits/edit/general/general.js
@@ -29,6 +29,7 @@ export default {
                 // language: "",
                 // template: "",
                 // idPrefix: ""
+                // idStart: 1
             },
             auditOrig: {},
             // List of existing clients

--- a/frontend/src/pages/audits/edit/general/general.js
+++ b/frontend/src/pages/audits/edit/general/general.js
@@ -27,7 +27,8 @@ export default {
                 // date_end: "",
                 // scope: [],
                 // language: "",
-                // template: ""
+                // template: "",
+                // idPrefix: ""
             },
             auditOrig: {},
             // List of existing clients
@@ -43,7 +44,7 @@ export default {
             // List of existing Languages
             languages: [],
             // List of existing audit types
-            auditTypes: []
+            auditTypes: [],
         }
     },
 

--- a/frontend/src/pages/audits/edit/index.vue
+++ b/frontend/src/pages/audits/edit/index.vue
@@ -86,7 +86,7 @@
 									>{{(finding.cvssSeverity)?finding.cvssSeverity.substring(0,1):"N"}}</q-chip>
 								</q-item-section>
 								<q-item-section>
-									<span>{{finding.title}}</span>
+									<span>{{audit.idPrefix}}{{formatVulnIdentifier(finding.identifier)}} {{finding.title}}</span>
 								</q-item-section>
 								<q-item-section side v-if="finding.status === 0">
 									<q-icon name="check" color="green" />

--- a/frontend/src/pages/audits/edit/index.vue
+++ b/frontend/src/pages/audits/edit/index.vue
@@ -86,7 +86,7 @@
 									>{{(finding.cvssSeverity)?finding.cvssSeverity.substring(0,1):"N"}}</q-chip>
 								</q-item-section>
 								<q-item-section>
-									<span>{{audit.idPrefix}}{{formatVulnIdentifier(finding.identifier)}} {{finding.title}}</span>
+									<span>{{displayIdentifier(finding)}} {{finding.title}}</span>
 								</q-item-section>
 								<q-item-section side v-if="finding.status === 0">
 									<q-icon name="check" color="green" />
@@ -242,6 +242,7 @@ export default {
 		},
 
 		methods: {
+			
 			getFindingColor: function(finding) {
 				if (finding.cvssSeverity && finding.cvssSeverity !== "None") {
 					if (finding.cvssSeverity === "Low") return "green"
@@ -258,9 +259,14 @@ export default {
 				return "light-blue";
 			},
 
-			formatVulnIdentifier: function(identifier) {
-				return identifier <= 999 ?  ("00" + identifier).slice(-3) : identifier;
+			displayIdentifier: function(finding) {
+				var formatIdentifier = (identifier) => {
+					return identifier <= 999 ?  ("00" + identifier).slice(-3) : identifier;
+				}
+				var calculatedIdentifier = finding.identifier + ((this.audit.idStart || 1 )- 1);
+				return `${this.audit.idPrefix}${formatIdentifier(calculatedIdentifier)}`; 
 			},
+			
 
 			// Sockets handle
 			handleSocket: function() {

--- a/frontend/src/pages/audits/edit/index.vue
+++ b/frontend/src/pages/audits/edit/index.vue
@@ -258,6 +258,10 @@ export default {
 				return "light-blue";
 			},
 
+			formatVulnIdentifier: function(identifier) {
+				return identifier <= 999 ?  ("00" + identifier).slice(-3) : identifier;
+			},
+
 			// Sockets handle
 			handleSocket: function() {
 				this.$socket.emit('join', {username: UserService.user.username, room: this.auditId});


### PR DESCRIPTION
Created a field in the audit general section to customize the ID prefix to be added in the generated reports. 
The motivation for this is that usually you create ID prefixes per project, where this prefix is an abbreviation of the project name. This makes it easier to change the prefix, without the need to have custom templates per project

Also added the id to the audit sidebar so you can easily distinguish the vulnerabilities already added.

By default the prefix is '#'

![image](https://user-images.githubusercontent.com/5262312/106358262-08493800-6303-11eb-8131-196411c46ee4.png)



EDIT:
Also added an offset to the id, so that ID's don't need to start at 1

Motivation for this is when you'rr asked to do a pentest of an app that was already pentested in the past. The client wants you to start ID's from the last from the last scan (just happened to me today)
![image](https://user-images.githubusercontent.com/5262312/108545803-2beb1700-72e0-11eb-9060-fcbeb6beca48.png)

