### PR TITLE
Add formatDate filter

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -92,22 +92,22 @@ exports.generateDoc = generateDoc;
 // *** Angular parser filters ***
 
 // Convert input date with parameter s (full,short): {input | convertDate: 's'}
-expressions.filters.convertDate = function(input, s) {
+expressions.filters.convertDate = function (input, s) {
     var date = new Date(input);
     if (date != "Invalid Date") {
-        var monthsFull = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-        var monthsShort = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"];
-        var days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-        var day = date.getUTCDate();
-        var month = date.getUTCMonth();
-        var year = date.getUTCFullYear();
         if (s === "full") {
-            return days[date.getUTCDay()] + ", " + monthsFull[month] + " " + (day<10 ? '0'+day: day) + ", " + year;
+            return utils.formatDate(date, "%w, %m %DD, %YYYY")
         }
         if (s === "short") {
-            return monthsShort[month] + "/" + (day<10 ? '0'+day: day) + "/" + year;
+            return utils.formatDate(date, "%MM/%DD/%YYYY")
         }
     }
+}
+
+expressions.filters.formatDate = function (input, format) {
+    var date = new Date(input);
+    if (date != "Invalid Date")
+        return utils.formatDate(date, format);
 }
 
 // Convert input date with parameter s (full,short): {input | convertDateLocale: 'locale':'style'}

--- a/backend/src/lib/utils.js
+++ b/backend/src/lib/utils.js
@@ -25,3 +25,37 @@ function escapeRegex(regex) {
     return regex.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
 }
 exports.escapeRegex = escapeRegex
+
+// format accepts any string and will replace the following placeholders:
+// %YY   - year (2 digits)
+// %YYYY - year (4 digits) 
+// %M    - month
+// %MM   - month (2 digits always), 
+// %m    - english month description
+// %D    - day, 
+// %DD   - day (2 digits always) 
+// %w    - english day of week 
+// %W    - day of week (number)
+function formatDate(date, format) {
+    var day = date.getUTCDate();
+    var dayOfWeek = date.getDay();
+    var month = date.getUTCMonth() + 1;
+    var year = date.getUTCFullYear();
+
+    var monthsFull = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+    var days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+    var formatedDate = format
+        .replace("%YYYY", year)
+        .replace("%YY", year)
+        .replace("%MM", month < 10 ? `0${month}` : month)
+        .replace("%M", month)
+        .replace("%m", monthsFull[month - 1])
+        .replace("%DD", day < 10 ? `0${day}` : day)
+        .replace("%D", day)
+        .replace("%W", dayOfWeek)
+        .replace("%w", days[dayOfWeek]);;
+
+    return formatedDate
+}
+exports.formatDate = formatDate;

--- a/docs/docxtemplate.md
+++ b/docs/docxtemplate.md
@@ -283,6 +283,29 @@ Convert Date to proper format. Must be used on values with date format.
 {date_start | convertDate: 'full'} -> Thursday, October 29, 2020
 >```
 
+### formatDate
+
+format date gives you more control on how to display a date.
+It provides a set of placeholder that can be used for formatting a date value:
+
+%YY   - year (2 digits)
+%YYYY - year (4 digits)
+%M    - month
+%MM   - month (2 digits always)
+%m    - english month description
+%D    - day, 
+%DD   - day (2 digits always)
+%w    - english day of week
+%W    - day of week (number)
+
+You can supply as a parameter a string with the format you want. The placeholder will be replaced by the respective values.
+
+> Use in template document
+// Example with {date_start: '2020-10-29'}
+{date_start | formatDate: '%MM/%DD/%YYYY'} -> 10/29/2020
+{date_start | formatDate: '%w, %m %DD, %YYYY'} -> Thursday, October 29, 2020
+>```
+
 ### convertDateLocale
 
 Convert Date to proper format using locale. Must be used on values with date format.


### PR DESCRIPTION
Created a template filter called formatDate so that users can use dates in the format they want to. 
It accepts a parameter which is the format to be used. Its a regular string, with placeholders. Placeholders will be replaced by their respective values

```
%YY   - year (2 digits)
%YYYY - year (4 digits)
%M    - month
%MM   - month (2 digits always)
%m    - english month description
%D    - day, 
%DD   - day (2 digits always)
%w    - english day of week
%W    - day of week (number)
```

// Example with {date_start: '2020-10-29'}
```
{date_start | formatDate: '%MM/%DD/%YYYY'} -> 10/29/2020
{date_start | formatDate: '%w, %m %DD, %YYYY'} -> Thursday, October 29, 2020
{date_start | formatDate: '%m %YYYY'} -> October 2020
```

Also adapted existing convertDate filter to work with the same logic under the hood. 
convertDate filter is still convenient to provide some out of the box formatted dates. 