### PR TITLE
Adding report config file containing cvss colors hex codes

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -6,9 +6,10 @@ var ImageModule = require('docxtemplater-image-module-free');
 var sizeOf = require('image-size');
 var customGenerator = require('./custom-generator');
 var utils = require('./utils');
-var html2ooxml = require('./html2ooxml')
+var html2ooxml = require('./html2ooxml');
 var _ = require('lodash');
-var Image = require('mongoose').model('Image')
+var Image = require('mongoose').model('Image');
+var reportConfig = require('./report.json');
 
 // Generate document with docxtemplater
 async function generateDoc(audit) {
@@ -202,11 +203,11 @@ var angularParser = function(tag) {
 // For each finding, add cvssColor, cvssObj and criteria colors parameters
 function cvssHandle(data) {
     // Header title colors
-    var noneColor = "4A86E8"; //blue
-    var lowColor = "008000"; //green
-    var mediumColor = "f9a009"; //yellow
-    var highColor = "fe0000"; //red
-    var criticalColor = "212121"; //black
+    var noneColor = reportConfig.cvss_colors.none_color; //default of blue ("4A86E8")
+    var lowColor = reportConfig.cvss_colors.low_color; //default of green ("008000")
+    var mediumColor = reportConfig.cvss_colors.medium_color; //default of yellow ("f9a009")
+    var highColor = reportConfig.cvss_colors.high_color; //default of red ("fe0000")
+    var criticalColor = reportConfig.cvss_colors.critical_color; //default of black ("212121")
 
     var cellNoneColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="' + noneColor + '"/></w:tcPr>';
     var cellLowColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="'+lowColor+'"/></w:tcPr>';

--- a/backend/src/lib/report.json
+++ b/backend/src/lib/report.json
@@ -1,0 +1,9 @@
+{
+    "cvss_colors" : {
+        "none_color" : "4A86E8",
+        "low_color" : "008000",
+        "medium_color" : "f9a009",
+        "high_color" : "fe0000",
+        "critical_color" : "212121" 
+    }
+}


### PR DESCRIPTION
This PR makes it easier to personalise the CVSS report colors by putting them in a config file instead of having to modify them in the code. 

If someone wants to use, for instance, the same colors used on first.org in his report, this person currently has to modify the hardcoded colors in the code. This change makes this action easier to perform as it extracts the color values and puts them in a config file which is much easier to read. 

Thanks! 