### PR TITLE
Fix error on some host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
     links:
       - mongodb
     networks: 
-      - backend
+      backend:
+        aliases:
+          - pwndoc-backend
 
   pwndoc-frontend:
     build: ./frontend


### PR DESCRIPTION
when i build with some host i have this error :

```
pwndoc-frontend    | 2021/10/28 07:46:33 [emerg] 1#1: host not found in upstream "pwndoc-backend" in /etc/nginx/conf.d/default.conf:19
pwndoc-frontend    | nginx: [emerg] host not found in upstream "pwndoc-backend" in /etc/nginx/conf.d/default.conf:19
pwndoc-frontend    | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
pwndoc-frontend    | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
pwndoc-frontend    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
pwndoc-frontend    | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
pwndoc-frontend    | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
pwndoc-frontend    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
pwndoc-frontend    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
pwndoc-frontend    | /docker-entrypoint.sh: Configuration complete; ready for start up
pwndoc-frontend    | 2021/10/28 07:47:26 [emerg] 1#1: host not found in upstream "pwndoc-backend" in /etc/nginx/conf.d/default.conf:19
pwndoc-frontend    | nginx: [emerg] host not found in upstream "pwndoc-backend" in /etc/nginx/conf.d/default.conf:19
```

to fix this issue we must specify an network aliases