### PR TITLE
Custom generator countCategory

### DIFF
--- a/backend/src/lib/custom-generator.js
+++ b/backend/src/lib/custom-generator.js
@@ -53,5 +53,19 @@ expressions.filters.convertDateFR = function(input, s) {
     }
 }
 
+// Count vulnerability by category
+// Example: {findings | countCategory: 'MyWebCategory'}
+expressions.filters.countCategory = function(input, category) {
+    if(!input) return input;
+    var count = 0;
+
+    for(var i = 0; i < input.length; i++){
+        if(input[i].category === category){
+            count += 1;
+        }
+    }
+    return count;
+}
+
 exports.expressions = expressions
 


### PR DESCRIPTION
Added custom generator to get the count of `findings` for a given `category`.

Usage:
- `{findings | countCategory: 'Web'}`
- `{findings | countCategory: 'Infra'}`
- `{findings | countCategory: 'Hardening'}`
- ...