### PR TITLE
Update report-generator.js to avoid `max stack size` in sub templating part

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -466,10 +466,12 @@ async function splitHTMLParagraphs(data) {
 function replaceSubTemplating(o, originalData = o){
     var regexp = /\{_\{([a-zA-Z0-9\[\]\_\.]{1,})\}_\}/gm;
     Object.getOwnPropertyNames(o).forEach(function(key) {
-        if(o[key] !== null && typeof o[key] === "object" )
-            o[key] = replaceSubTemplating(o[key], originalData)
-        else if(typeof o[key] === 'string')
-            o[key]  = o[key].replaceAll(regexp, (match, word) =>  _.get(originalData,word.trim(),''))
+        if(!key.startsWith('_')){
+            if(o[key] !== null && typeof o[key] === "object" )
+                o[key] = replaceSubTemplating(o[key], originalData)
+            else if(typeof o[key] === 'string')
+                o[key]  = o[key].replaceAll(regexp, (match, word) =>  _.get(originalData,word.trim(),''))
+        }
     })
     return o
 }


### PR DESCRIPTION
To avoid `max stack size` else the code enter in infinite loop with recursive call because of the key `__parrentArray` (come from mangoose)