### PR TITLE
Security Hardening

### DIFF
--- a/frontend/.docker/nginx.conf
+++ b/frontend/.docker/nginx.conf
@@ -4,7 +4,13 @@ server {
     ssl_certificate     /etc/nginx/ssl/server.cert;
     ssl_certificate_key /etc/nginx/ssl/server.key;
     ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_ciphers         'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384';
+    ssl_ciphers         "EECDH+AESGCM:EDH+AESGCM";
+    ssl_prefer_server_ciphers   on;
+    ssl_ecdh_curve      secp384r1;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_stapling        on;
+    ssl_stapling_verify on;
 
     #Additional Server Settings
     server_tokens       off;

--- a/frontend/.docker/nginx.conf
+++ b/frontend/.docker/nginx.conf
@@ -3,8 +3,31 @@ server {
     server_name         localhost;
     ssl_certificate     /etc/nginx/ssl/server.cert;
     ssl_certificate_key /etc/nginx/ssl/server.key;
-    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384';
+
+    #Additional Server Settings
+    server_tokens       off;
+    charset             utf-8;
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+
+    #Additional Headers
+    add_header Cache-Control "no-store, max-age=0";
+    add_header Clear-Site-Data "*";
+    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+    add_header Cross-Origin-Embedder-Policy "require-corp";
+    add_header Cross-Origin-Opener-Policy "same-origin";
+    add_header Cross-Origin-Resource-Policy "same-origin";
+    add_header Feature-policy "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'";
+    add_header Pragma "no-chace";
+    add_header Referrer-Policy "strict-origin";
+    add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Permitted-Cross-Domain-Policies "none";
+    add_header X-XSS-Protection "1; mode=block";
 
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;


### PR DESCRIPTION
**Updated security headers to align with OWASP Security Header project**
- Cache-Control
- Clear-Site-Data
- Content-Security-Policy
- Cross-Origin-Embedder-Policy
- Cross-Origin-Opener-Policy
- Cross-Origin-Resource-Policy
- Feature-policy
- Pragma
- Referrer-Policy
- Strict-Transport-Security
- X-Content-Type-Options
- X-Frame-Options
- X-Permitted-Cross-Domain-Policies
- X-XSS-Protection (**Note**: This header is technically depreciated, but some security scanners still trigger an alert when it's not shown in the response headers)

**Hardened TLS Posture**
- Removed weak ciphers for TLSv1.2
- Enabled TLSv1.3
- Enabled prefer_server_ciphers
- Configured ECDH curve cipher
- Enabled session cache and stapling (**Note**: Stapling will not engage on a self-signed certificate, but will not stall or halt the service if enabled. If someone sets up PwnDoc in the future and adds their own valid certificate, then the server is pre-configured for stapling.)

**Additional server configurations the web application**
- Disabled server tokens to hide version
- Enforce UTF-8 character set
- Enabled tcp_nopush and tcp_nodelay for a slight speed increase