### PR TITLE
Implementation of a darkmode

### DIFF
--- a/frontend/quasar.conf.js
+++ b/frontend/quasar.conf.js
@@ -9,7 +9,8 @@ module.exports = function (ctx) {
       'axios',
       'affix',
       'auth',
-      'i18n', 
+      'i18n',
+      'darkmode',
       'lodash',
       'socketio',
       'settings'

--- a/frontend/src/boot/darkmode.js
+++ b/frontend/src/boot/darkmode.js
@@ -1,0 +1,30 @@
+import Vue from "vue";
+import { Dark } from "quasar";
+
+const DarkModeSwitcher = {
+    install: function(Vue) {
+        Vue.prototype.toggleDarkMode = function() {
+            updateDarkMode(!Dark.isActive);
+        }
+    }
+};
+Vue.use(DarkModeSwitcher);
+
+function updateDarkMode(dark = null) {
+    // using !! to convert it to a boolean is ok in this case,
+    // because we are checking, if the key exists
+    let darkmode = !!localStorage.getItem("darkmodeEnabled") || false;
+    if(dark != null) {
+        // set mode
+        darkmode = dark;
+    }
+    
+    Dark.set(darkmode);
+    if(darkmode) {
+      localStorage.setItem("darkmodeEnabled", "y");
+    } else {
+      localStorage.removeItem("darkmodeEnabled");
+    }
+}
+
+updateDarkMode();

--- a/frontend/src/components/custom-fields.vue
+++ b/frontend/src/components/custom-fields.vue
@@ -9,7 +9,7 @@
                 label-slot 
                 stack-label 
                 borderless
-                :class="(isTextInCustomFields(field))?'bg-red-1':'white'"
+                :class="(isTextInCustomFields(field))?'bg-red-1':null"
                 :hint="field.customField.description"
                 hide-bottom-space
                 :rules="(field.customField.required)? [val => !!val || 'Field is required']: []"
@@ -44,7 +44,7 @@
                 stack-label
                 v-model="field.text"
                 :readonly="readonly"
-                :bg-color="(isTextInCustomFields(field))?'red-1':'white'"
+                :bg-color="(isTextInCustomFields(field))?'red-1':null"
                 :hint="field.customField.description"
                 hide-bottom-space
                 :rules="(field.customField.required)? [val => !!val || 'Field is required']: []"
@@ -63,7 +63,7 @@
                 stack-label
                 v-model="field.text"
                 :readonly="readonly"
-                :bg-color="(isTextInCustomFields(field))?'red-1':'white'"
+                :bg-color="(isTextInCustomFields(field))?'red-1':null"
                 :hint="field.customField.description"
                 hide-bottom-space
                 :rules="(field.customField.required)? [val => !!val || 'Field is required']: []"
@@ -96,7 +96,7 @@
                 options-sanitize
                 outlined 
                 :readonly="readonly"
-                :bg-color="(isTextInCustomFields(field))?'red-1':'white'"
+                :bg-color="(isTextInCustomFields(field))?'red-1':null"
                 :hint="field.customField.description"
                 hide-bottom-space
                 :rules="(field.customField.required)? [val => !!val || 'Field is required']: []"
@@ -123,7 +123,7 @@
                 options-sanitize
                 outlined 
                 :readonly="readonly"
-                :bg-color="(isTextInCustomFields(field))?'red-1':'white'"
+                :bg-color="(isTextInCustomFields(field))?'red-1':null"
                 :hint="field.customField.description"
                 hide-bottom-space
                 :rules="(field.customField.required)? [val => !!val || 'Field is required', val => val && val.length > 0 || 'Field is required']: []"
@@ -157,7 +157,7 @@
                 hide-bottom-space
                 outlined
                 :readonly="readonly"
-                :bg-color="(isTextInCustomFields(field))?'red-1':'white'"
+                :bg-color="(isTextInCustomFields(field))?'red-1':null"
                 :rules="(field.customField.required)? [val => !!val || 'Field is required', val => val && val.length > 0 || 'Field is required']: []"
                 lazy-rules="ondemand"
                 >
@@ -185,7 +185,7 @@
                 hide-bottom-space
                 outlined
                 :readonly="readonly"
-                :bg-color="(isTextInCustomFields(field))?'red-1':'white'"
+                :bg-color="(isTextInCustomFields(field))?'red-1':null"
                 :rules="(field.customField.required)? [val => !!val || 'Field is required']: []"
                 lazy-rules="ondemand"
                 >

--- a/frontend/src/components/textarea-array.vue
+++ b/frontend/src/components/textarea-array.vue
@@ -6,7 +6,6 @@
     type="textarea"
     @input="updateParent"
     outlined 
-    bg-color="white"
     :readonly="readonly"
     />
 </template>

--- a/frontend/src/layouts/home.vue
+++ b/frontend/src/layouts/home.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-layout ref="layout" view="hHr LpR lFf" class="home-background">
+  <q-layout ref="layout" view="hHr LpR lFf" :class="$q.dark.isActive ? '' : 'home-background'">
     <q-header>
         <q-toolbar color="primary">
             <img src="pwndoc-logo-white.png" style="max-height:50px;" />
@@ -35,6 +35,10 @@
               </q-item>
             <q-btn-dropdown auto-close flat icon="fa fa-user-circle" no-caps :label="userService.user.username">
                 <q-list>
+                  <q-item clickable @click="toggleDarkMode()">
+                    <q-item-section side><q-icon size="xs" :name="$q.dark.isActive ? 'fa fa-sun' : 'fa fa-moon'" /></q-item-section>
+                    <q-item-section>{{ $q.dark.isActive ? 'Light' : 'Dark'}}-Mode</q-item-section>
+                  </q-item>
                   <q-item clickable @click="$router.push('/profile')">
                     <q-item-section side><q-icon size="xs" name="fa fa-id-card" /></q-item-section>
                     <q-item-section>{{$t('profile')}}</q-item-section>

--- a/frontend/src/pages/audits/edit/findings/add/add.html
+++ b/frontend/src/pages/audits/edit/findings/add/add.html
@@ -6,8 +6,6 @@
     <div class="col-md-10 offset-md-1">
         <q-table
         class="sticky-header-table-addfinding"
-        card-class="bg-grey-1"
-        table-header-class="bg-grey-1"
         :columns="dtVulnHeaders"
         :data="vulnerabilities"
         :filter="search"
@@ -30,10 +28,9 @@
                 @input="getVulnerabilities"
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
                 <q-space />
-                <q-input v-model="findingTitle" :label="$t('title')" class="q-pl-md col-md-6" @keyup.enter="addFinding()" outlined bg-color="white">
+                <q-input v-model="findingTitle" :label="$t('title')" class="q-pl-md col-md-6" @keyup.enter="addFinding()" outlined>
                     <template v-slot:append>
                         <q-btn-dropdown :label="$t('btn.create')" no-caps flat>
                             <q-list separator>
@@ -64,7 +61,6 @@
                         v-model="search.title"
                         clearable
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 20%">
@@ -77,7 +73,6 @@
                         :options="vulnCategoriesOptions"
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 20%">
@@ -90,7 +85,6 @@
                         :options="vulnTypeOptions"
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td></q-td>

--- a/frontend/src/pages/audits/edit/findings/edit/edit.html
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.html
@@ -21,7 +21,7 @@
 </breadcrumb>
 
 <div class="row">
-    <q-tabs v-model="selectedTab" align="left" indicator-color="primary" :class="'full-width' + this.$q.dark.isActive ? '' : ' bg-white'">
+    <q-tabs v-model="selectedTab" align="left" indicator-color="primary" :class="'full-width' + (this.$q.dark.isActive ? '' : ' bg-white')">
         <q-tab name="definition" default :label="$t('definition')" />
         <q-tab name="proofs" :label="$t('proofs')"/>
         <q-tab name="details" :label="$t('details')" />

--- a/frontend/src/pages/audits/edit/findings/edit/edit.html
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.html
@@ -21,7 +21,7 @@
 </breadcrumb>
 
 <div class="row">
-    <q-tabs v-model="selectedTab" align="left" indicator-color="primary" class="bg-white full-width">
+    <q-tabs v-model="selectedTab" align="left" indicator-color="primary" :class="'full-width' + this.$q.dark.isActive ? '' : ' bg-white'">
         <q-tab name="definition" default :label="$t('definition')" />
         <q-tab name="proofs" :label="$t('proofs')"/>
         <q-tab name="details" :label="$t('details')" />
@@ -34,9 +34,9 @@
 
     <q-tab-panels v-model="selectedTab" animated class="bg-transparent col-md-8 col-12 offset-md-2 q-mt-md" @before-transition="syncEditors" @transition="updateOrig" >
         <q-tab-panel name="definition">
-            <q-card class="bg-grey-1">
+            <q-card>
                 <q-card-section class="row q-col-gutter-md">
-                    <q-input class="col-md-8 col-12" :label="$t('title')+' *'" stack-label v-model="finding.title" outlined bg-color="white" :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"/>
+                    <q-input class="col-md-8 col-12" :label="$t('title')+' *'" stack-label v-model="finding.title" outlined :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"/>
                     <q-select 
                     class="col-md-4 col-12"
                     :label="$t('type')"
@@ -48,7 +48,6 @@
                     map-options
                     options-sanitize
                     outlined
-                    bg-color="white"
                     :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                     />
                     <q-field class="col-md-12" borderless :label="$t('description')" stack-label>
@@ -85,7 +84,7 @@
         <q-tab-panel name="proofs">
             <div class="q-col-gutter-md row">
                 <div class="col-12">
-                    <q-card class="bg-grey-1">
+                    <q-card>
                         <q-card-section>
                             <basic-editor ref="basiceditor_poc" noSync v-model="finding.poc" :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"/>
                         </q-card-section>
@@ -94,7 +93,7 @@
             </div>
         </q-tab-panel>
         <q-tab-panel name="details">
-            <q-card class="bg-grey-1">
+            <q-card>
                 <q-card-section>{{$t('affectedAssets')}}</q-card-section>
                 <q-separator />
                 <q-card-section>
@@ -114,7 +113,7 @@
                     />
                 </div>
             </q-card>
-            <q-card class="q-mt-md bg-grey-1">
+            <q-card class="q-mt-md">
                 <q-card-section>{{$t('courseOfActions')}}</q-card-section>
                 <q-separator />
                 <q-card-section>
@@ -129,7 +128,6 @@
                         emit-value
                         options-sanitize
                         outlined
-                        bg-color="white"
                         :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                         />
                         <q-select
@@ -142,7 +140,6 @@
                         emit-value
                         options-sanitize
                         outlined
-                        bg-color="white"
                         :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                         />
                     </div>

--- a/frontend/src/pages/audits/edit/general/general.html
+++ b/frontend/src/pages/audits/edit/general/general.html
@@ -7,10 +7,10 @@
 
 <div class="row q-col-gutter-md q-pa-md">
     <div class="col-md-8 offset-md-2 col-12">
-        <q-card class="bg-grey-1">
+        <q-card>
             <q-card-section>
                 <div class="row q-col-gutter-md">
-                    <q-input class="col-md-6 col-12" :label="$t('name')+' *'" v-model="audit.name" outlined bg-color="white" :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"/>
+                    <q-input class="col-md-6 col-12" :label="$t('name')+' *'" v-model="audit.name" outlined :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"/>
                     <div class="col"></div>
                     <q-select 
                     class="col-md-6 col-12"
@@ -23,7 +23,6 @@
                     map-options
                     options-sanitize
                     outlined 
-                    bg-color="white"
                     :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                     />
                     <q-select
@@ -37,7 +36,6 @@
                     map-options
                     options-sanitize
                     outlined 
-                    bg-color="white"
                     :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                     /> 
                 </div>
@@ -62,7 +60,6 @@
                     options-sanitize
                     use-input
                     outlined 
-                    bg-color="white"
                     :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                     color="secondary"
                     />
@@ -78,7 +75,6 @@
                     clearable
                     options-sanitize
                     outlined 
-                    bg-color="white"
                     :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                     />
                     <q-select 
@@ -94,7 +90,6 @@
                     use-chips
                     options-sanitize
                     outlined 
-                    bg-color="white"
                     :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                     >
                         <template v-slot:selected-item="scope">
@@ -123,7 +118,6 @@
                     use-chips
                     options-sanitize
                     outlined 
-                    bg-color="white"
                     :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT"
                     >
                         <template v-slot:after>
@@ -156,7 +150,7 @@
 
             <q-card-section>
                 <div class="row q-col-gutter-md">
-                    <q-input class="col-md-4 col-12" :label="$t('startDate')" v-model="audit.date_start" outlined bg-color="white" :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT">
+                    <q-input class="col-md-4 col-12" :label="$t('startDate')" v-model="audit.date_start" outlined :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT">
                         <template v-slot:append>
                             <q-icon name="event" class="cursor-pointer">
                             <q-popup-proxy ref="qDateStartProxy" transition-show="scale" transition-hide="scale">
@@ -165,7 +159,7 @@
                             </q-icon>
                         </template>
                     </q-input>
-                    <q-input class="col-md-4 col-12" :label="$t('endDate')" v-model="audit.date_end" outlined bg-color="white" :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT">
+                    <q-input class="col-md-4 col-12" :label="$t('endDate')" v-model="audit.date_end" outlined :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT">
                         <template v-slot:append>
                             <q-icon name="event" class="cursor-pointer">
                             <q-popup-proxy ref="qDateEndProxy" transition-show="scale" transition-hide="scale">
@@ -174,7 +168,7 @@
                             </q-icon>
                         </template>
                     </q-input>
-                    <q-input class="col-md-4 col-12" :label="$t('reportingDate')" v-model="audit.date" outlined bg-color="white" :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT">
+                    <q-input class="col-md-4 col-12" :label="$t('reportingDate')" v-model="audit.date" outlined :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT">
                         <template v-slot:append>
                             <q-icon name="event" class="cursor-pointer">
                             <q-popup-proxy ref="qDateProxy" transition-show="scale" transition-hide="scale">

--- a/frontend/src/pages/audits/edit/network/network.html
+++ b/frontend/src/pages/audits/edit/network/network.html
@@ -2,11 +2,9 @@
     <breadcrumb buttons :title="`${$parent.audit.name} (${$parent.audit.auditType || 'Audit Type not set'})`" :state="parentState" :approvals="parentApprovals">
     <div slot="buttons" v-if="frontEndAuditState === AUDIT_VIEW_STATE.EDIT">
         <q-btn-dropdown 
-        class="q-mr-sm" 
-        :label="$t('import')" 
-        no-caps 
-        color="grey-4" 
-        text-color="black"
+        class="q-mr-sm"
+        :label="$t('import')"
+        no-caps
         auto-close
         >
             <q-list>

--- a/frontend/src/pages/audits/edit/sections/sections.html
+++ b/frontend/src/pages/audits/edit/sections/sections.html
@@ -7,7 +7,7 @@
 
 <div class="row q-col-gutter-md q-pa-md">
     <div class="col-md-8 offset-md-2">
-        <q-card class="bg-grey-1">
+        <q-card>
             <!-- For retrocompatibility, test if section.text exists -->
             <q-card-section v-if="section.text"> 
                 <basic-editor ref="basiceditor_section" noSync v-model="section.text" :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT" />

--- a/frontend/src/pages/audits/list/audits-list.html
+++ b/frontend/src/pages/audits/list/audits-list.html
@@ -9,8 +9,6 @@
     <div v-if="languages.length > 0 && auditTypes.length > 0" class="col-md-8 col-12 offset-md-2 q-mt-md">
         <q-table
             class="sticky-header-table"
-            card-class="bg-grey-1"
-            table-header-class="bg-grey-1"
             :columns="dtHeaders"
             :visible-columns="visibleColumns"
             :data="audits"
@@ -30,7 +28,6 @@
                 v-model="search.finding"
                 @keyup.enter="getAudits"
                 outlined
-                bg-color="white"
                 >
                     <template v-slot:append>
                         <q-btn flat icon="search" @click="getAudits" />
@@ -66,7 +63,6 @@
                             clearable
                             :autofocus="col.name === 'name'"
                             outlined
-                            bg-color="white"
                             />
                         </div>
                         <div v-else-if="col.name === 'company'">
@@ -83,7 +79,6 @@
                                 clearable
                                 options-sanitize
                                 outlined
-                                bg-color="white"
                                 />
                         </div>
                         <div v-else-if="col.name === 'language'">
@@ -100,7 +95,6 @@
                             clearable
                             options-sanitize
                             outlined
-                            bg-color="white"
                             />
                         </div>
                     </q-td>

--- a/frontend/src/pages/data/clients/clients.html
+++ b/frontend/src/pages/data/clients/clients.html
@@ -3,8 +3,6 @@
     <div class="col-md-10 col-12 offset-md-1 q-mt-md">
         <q-table
             class="sticky-header-table"
-            card-class="bg-grey-1"
-            table-header-class="bg-grey-1"
             :columns="dtHeaders"
             :data="clients"
             :filter="search"
@@ -36,7 +34,6 @@
                         v-model="search.firstname"
                         clearable
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 25%">
@@ -47,7 +44,6 @@
                         v-model="search.lastname"
                         clearable
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 25%">
@@ -58,7 +54,6 @@
                         v-model="search.email"
                         clearable
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 25%">
@@ -75,7 +70,6 @@
                         emit-value
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td></q-td>
@@ -115,7 +109,7 @@
 </div>
 
 <q-dialog ref="createModal" persistent @hide="cleanErrors()">
-    <q-card persistent style="width:800px" class="bg-grey-1">
+    <q-card persistent style="width:800px">
         <q-bar class="bg-primary text-white">
             <span>{{$t('addClient')}}</span>
             <q-space />
@@ -133,7 +127,6 @@
             option-label="name"
             options-sanitize
             outlined
-            bg-color="white"
             />
         </q-card-section>
         <q-card-section>
@@ -146,7 +139,6 @@
             @keyup.enter="createClient()"
             v-model="currentClient.firstname" 
             outlined
-            bg-color="white"
             />
         </q-card-section>
         <q-card-section>
@@ -158,7 +150,6 @@
             @keyup.enter="createClient()"
             v-model="currentClient.lastname"
             outlined
-            bg-color="white"
             />
         </q-card-section>
         <q-card-section>
@@ -170,7 +161,6 @@
             @keyup.enter="createClient()"
             v-model="currentClient.email" 
             outlined
-            bg-color="white"
             />
         </q-card-section>
         <q-card-section>
@@ -179,7 +169,6 @@
             @keyup.enter="createClient()"
             v-model="currentClient.title" 
             outlined
-            bg-color="white"
             />
         </q-card-section>
         <q-card-section>
@@ -188,7 +177,6 @@
             @keyup.enter="createClient()"
             v-model="currentClient.phone" 
             outlined
-            bg-color="white"
             />
         </q-card-section>
         <q-card-section>
@@ -197,7 +185,6 @@
             @keyup.enter="createClient()"
             v-model="currentClient.cell" 
             outlined
-            bg-color="white"
             />
         </q-card-section>  
                 
@@ -211,7 +198,7 @@
 </q-dialog>
 
 <q-dialog ref="editModal" persistent @hide="cleanErrors()">
-    <q-card persistent style="width:800px" class="bg-grey-1">
+    <q-card persistent style="width:800px">
         <q-bar class="bg-primary text-white">
             <span>{{$t('editClient')}}</span>
             <q-space />
@@ -229,7 +216,6 @@
                 option-label="name"
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -241,7 +227,6 @@
                 @keyup.enter="updateClient()"
                 v-model="currentClient.firstname" 
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -254,7 +239,6 @@
                 @keyup.enter="updateClient()"
                 v-model="currentClient.lastname"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -266,7 +250,6 @@
                 @keyup.enter="updateClient()"
                 v-model="currentClient.email" 
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -275,7 +258,6 @@
                 @keyup.enter="updateClient()"
                 v-model="currentClient.title" 
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -284,7 +266,6 @@
                 @keyup.enter="updateClient()"
                 v-model="currentClient.phone" 
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -293,7 +274,6 @@
                 @keyup.enter="updateClient()"
                 v-model="currentClient.cell" 
                 outlined
-                bg-color="white"
                 />
             </q-card-section>  
         

--- a/frontend/src/pages/data/collaborators/collaborators.html
+++ b/frontend/src/pages/data/collaborators/collaborators.html
@@ -3,8 +3,6 @@
         <div class="col-md-10 col-12 offset-md-1 q-mt-md">
             <q-table
                 class="sticky-header-table"
-                card-class="bg-grey-1"
-                table-header-class="bg-grey-1"
                 :columns="dtHeaders"
                 :data="collabs"
                 :filter="search"
@@ -36,7 +34,6 @@
                             v-model="search.username"
                             clearable
                             outlined
-                            bg-color="white"
                             />
                         </q-td>
                         <q-td style="width: 20%">
@@ -47,7 +44,6 @@
                             v-model="search.firstname"
                             clearable
                             outlined
-                            bg-color="white"
                             />
                         </q-td>
                         <q-td style="width: 20%">
@@ -58,7 +54,6 @@
                             v-model="search.lastname"
                             clearable
                             outlined
-                            bg-color="white"
                             />
                         </q-td>
                         <q-td style="width: 20%">
@@ -69,7 +64,6 @@
                             v-model="search.email"
                             clearable
                             outlined
-                            bg-color="white"
                             />
                         </q-td>
                         <q-td style="width: 20%">
@@ -82,7 +76,6 @@
                             :options="roles"
                             options-sanitize
                             outlined
-                            bg-color="white"
                             />
                         </q-td>
                     </q-tr>
@@ -121,7 +114,7 @@
     </div>
     
     <q-dialog ref="createModal" persistent @hide="cleanErrors()">
-        <q-card style="width:800px" class="bg-grey-1">
+        <q-card style="width:800px">
             <q-bar class="bg-primary text-white">
                 <div class="q-toolbar-title">
                     {{$t('addCollaborator')}}
@@ -141,7 +134,6 @@
                 @keyup.enter="createCollab()"
                 v-model="currentCollab.username"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -154,7 +146,6 @@
                 @keyup.enter="createCollab()"
                 v-model="currentCollab.firstname"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>  
             <q-card-section>
@@ -167,7 +158,6 @@
                 @keyup.enter="createCollab()"
                 v-model="currentCollab.lastname"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -178,7 +168,6 @@
                 @keyup.enter="createCollab()"
                 v-model="currentCollab.email"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -189,7 +178,6 @@
                 @keyup.enter="createCollab()"
                 v-model="currentCollab.phone"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -201,7 +189,6 @@
                 @keyup.enter="createCollab()"
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -214,7 +201,6 @@
                 hide-bottom-space
                 @keyup.enter="createCollab()"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
     
@@ -228,7 +214,7 @@
     </q-dialog>
     
     <q-dialog ref="editModal" persistent @hide="cleanErrors()">
-        <q-card style="width:800px" class="bg-grey-1">
+        <q-card style="width:800px">
             <q-bar class="bg-primary text-white">
                 <div class="q-toolbar-title">
                     {{$t('editCollaborator')}}
@@ -282,7 +268,6 @@
                 @keyup.enter="updateCollab()"
                 v-model="currentCollab.email"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -293,7 +278,6 @@
                 @keyup.enter="updateCollab()"
                 v-model="currentCollab.phone"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>

--- a/frontend/src/pages/data/collaborators/collaborators.html
+++ b/frontend/src/pages/data/collaborators/collaborators.html
@@ -248,7 +248,6 @@
                 @keyup.enter="updateCollab()"
                 v-model="currentCollab.username"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -261,7 +260,6 @@
                 @keyup.enter="updateCollab()"
                 v-model="currentCollab.firstname"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>  
             <q-card-section>
@@ -274,7 +272,6 @@
                 @keyup.enter="updateCollab()"
                 v-model="currentCollab.lastname"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>
@@ -308,7 +305,6 @@
                 @keyup.enter="updateCollab()"
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
             </q-card-section>   
             <q-card-section>
@@ -318,7 +314,6 @@
                 type="password"
                 @keyup.enter="updateCollab()"
                 outlined
-                bg-color="white"
                 />
             </q-card-section>
             <q-card-section>

--- a/frontend/src/pages/data/companies/companies.html
+++ b/frontend/src/pages/data/companies/companies.html
@@ -77,7 +77,7 @@
 </div>
 
 <q-dialog ref="createModal" persistent @hide="cleanErrors()">
-    <q-card style="width:800px" class="bg-grey-1">
+    <q-card style="width:800px">
         <q-bar class="bg-primary text-white">
             <div class="q-toolbar-title">
                 {{$t('addCompany')}}
@@ -118,7 +118,7 @@
 </q-dialog>
 
 <q-dialog ref="editModal" persistent @hide="cleanErrors()">
-    <q-card style="width:800px" class="bg-grey-1">
+    <q-card style="width:800px">
         <q-bar class="bg-primary text-white">
             <div class="q-toolbar-title">
                 {{$t('editCompany')}}

--- a/frontend/src/pages/data/companies/companies.html
+++ b/frontend/src/pages/data/companies/companies.html
@@ -3,8 +3,6 @@
     <div class="col-md-10 col-12 offset-md-1 q-mt-md">
         <q-table
             class="sticky-header-table"
-            card-class="bg-grey-1"
-            table-header-class="bg-grey-1"
             :columns="dtHeaders"
             :data="companies"
             :filter="search"
@@ -35,7 +33,6 @@
                         v-model="search.name"
                         clearable
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td></q-td>
@@ -100,7 +97,6 @@
                     @keyup.enter="createCompany()"
                     v-model="currentCompany.name" 
                     outlined
-                    bg-color="white"
                     />
                 <q-uploader
                     ref="addUploader"
@@ -143,7 +139,6 @@
                     @keyup.enter="updateCompany()"
                     v-model="currentCompany.name"
                     outlined
-                    bg-color="white"
                     />
                 <q-uploader
                     ref="addUploader"

--- a/frontend/src/pages/data/custom/custom.html
+++ b/frontend/src/pages/data/custom/custom.html
@@ -14,7 +14,7 @@
 
             <!-- LANGUAGES -->
             <q-tab-panel name="languages">
-                <q-card class="bg-grey-1">
+                <q-card>
                     <q-card-section>
                         <div class="text-grey-8">{{$t('languageUsedInAuditsAndVuls')}}</div>
                     </q-card-section>
@@ -31,7 +31,6 @@
                                     lazy-rules="ondemand"
                                     @keyup.enter="createLanguage"
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                                 <q-item-section>
@@ -44,7 +43,6 @@
                                     lazy-rules="ondemand"
                                     @keyup.enter="createLanguage"
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                                 <q-item-section side>
@@ -54,7 +52,7 @@
                         </div>
                         
                         <div v-if="!editLanguage" class="col-md-6 col-12">
-                            <q-card flat bordered v-if="languages.length > 0" class="bg-grey-1">
+                            <q-card flat bordered v-if="languages.length > 0">
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('listOfLanguages')}}</div>
                                     <q-space />
@@ -71,7 +69,6 @@
                                             v-model="language.language"
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             />
                                         </q-item-section>
                                         <q-item-section>
@@ -80,7 +77,6 @@
                                             v-model="language.locale"
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             />
                                         </q-item-section>
                                     </q-item>
@@ -88,7 +84,7 @@
                             </q-card>
                         </div>
                         <div v-else class="col-md-6 col-12">
-                            <q-card flat bordered class="bg-grey-1">
+                            <q-card flat bordered>
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('editLanguages')}}</div>
                             </q-toolbar>
@@ -104,7 +100,6 @@
                                                 :label="$t('language')"
                                                 v-model="language.language"
                                                 outlined
-                                                bg-color="white"
                                                 />
                                             </q-item-section>
                                             <q-item-section>
@@ -112,7 +107,6 @@
                                                 :label="$t('locale')"
                                                 v-model="language.locale"
                                                 outlined
-                                                bg-color="white"
                                                 />
                                             </q-item-section>
                                             <q-item-section side >
@@ -133,7 +127,7 @@
 
             <!-- AUDIT TYPES -->
             <q-tab-panel name="audit-types">
-                <q-card class="bg-grey-1">
+                <q-card>
                     <q-card-section>
                         <div class="text-grey-8">{{$t('auditTypesUsedInAudits')}}</div>
                     </q-card-section>
@@ -151,7 +145,6 @@
                                     lazy-rules="ondemand"
                                     @keyup.enter="createAuditType"
                                     outlined
-                                    bg-color="white"
                                     >
                                         <template v-slot:label>
                                             {{$t('name')}} <span class="text-red">*</span>
@@ -172,7 +165,6 @@
                                         options-sanitize
                                         map-options
                                         outlined
-                                        bg-color="white"
                                         :rules="[val => !!val || 'Field is required']"
                                         lazy-rules="ondemand"
                                         >
@@ -197,7 +189,6 @@
                                     map-options 
                                     options-sanitize
                                     outlined
-                                    bg-color="white"
                                     >
                                         <template v-slot:selected-item="scope">
                                             <q-chip
@@ -226,7 +217,7 @@
                         </div>
 
                         <div v-if="!editAuditType" class="col-md-6 col-12">
-                            <q-card flat bordered v-if="auditTypes.length > 0" class="bg-grey-1">
+                            <q-card flat bordered v-if="auditTypes.length > 0">
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('listOfAuditTypes')}}</div>
                                     <q-space />
@@ -252,7 +243,6 @@
                                                         map-options 
                                                         options-sanitize
                                                         outlined
-                                                        bg-color="white"
                                                         />
                                                     </div>
                                                 </q-item-section>
@@ -272,7 +262,6 @@
                                                     map-options 
                                                     options-sanitize
                                                     outlined
-                                                    bg-color="white"
                                                     >
                                                         <template v-slot:selected-item="scope">
                                                             <q-chip
@@ -301,7 +290,7 @@
                             </q-card>
                         </div>
                         <div v-else class="col-md-6 col-12">
-                            <q-card flat bordered class="bg-grey-1">
+                            <q-card flat bordered>
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('editAuditTypes')}}</div>
                             </q-toolbar>
@@ -325,7 +314,6 @@
                                                             :rules="[val => !!val || 'Name is required']"
                                                             lazy-rules="ondemand"
                                                             outlined
-                                                            bg-color="white"
                                                             >
                                                                 <template v-slot:label>
                                                                     {{$t('name')}} <span class="text-red">*</span>
@@ -348,7 +336,6 @@
                                                                 map-options
                                                                 emit-value
                                                                 outlined
-                                                                bg-color="white"
                                                                 :rules="[val => !!val || 'Field is required']"
                                                                 lazy-rules="ondemand"
                                                                 >
@@ -368,7 +355,6 @@
                                                                 options-sanitize
                                                                 map-options
                                                                 outlined
-                                                                bg-color="white"
                                                                 :rules="[val => !!val || 'Field is required']"
                                                                 lazy-rules="ondemand"
                                                                 >
@@ -393,7 +379,6 @@
                                                             map-options 
                                                             options-sanitize
                                                             outlined
-                                                            bg-color="white"
                                                             >
                                                                 <template v-slot:selected-item="scope">
                                                                     <q-chip
@@ -440,7 +425,7 @@
 
             <!-- VULNERABILITY TYPES -->
             <q-tab-panel name="vulnerability-types">
-                <q-card class="bg-grey-1">
+                <q-card>
                     <q-card-section>
                         <div class="text-grey-8">{{$t('createVulnerabilityTypes')}}</div>
                     </q-card-section>
@@ -458,7 +443,6 @@
                                     map-options 
                                     options-sanitize
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                             </q-item>
@@ -472,7 +456,6 @@
                                     :error-message="errors.vulnType"
                                     @keyup.enter="createVulnerabilityType"
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                                 <q-item-section side>
@@ -482,7 +465,7 @@
                         </div>
 
                         <div v-if="!editVulnType" class="col-md-6 col-12">
-                            <q-card flat bordered v-if="vulnTypes.length > 0" class="bg-grey-1">
+                            <q-card flat bordered v-if="vulnTypes.length > 0">
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('vulnerabilityTypesList')}}</div>
                                     <q-space />
@@ -498,14 +481,13 @@
                                         v-model="vulnType.name"
                                         readonly
                                         outlined
-                                        bg-color="white"
                                         />
                                     </q-item-section>
                                 </q-item>
                             </q-card>
                         </div>
                         <div v-else class="col-md-6 col-12">
-                            <q-card flat bordered class="bg-grey-1">
+                            <q-card flat bordered>
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('editVulnerabilityTypes')}}</div>
                             </q-toolbar>
@@ -521,7 +503,6 @@
                                                 :label="$t('name')"
                                                 v-model="vulnType.name"
                                                 outlined
-                                                bg-color="white"
                                                 />
                                             </q-item-section>
                                             <q-item-section side >
@@ -545,7 +526,7 @@
 
             <!-- VULNERABILITY CATEGORIES -->
             <q-tab-panel name="vulnerability-categories">
-                <q-card class="bg-grey-1">
+                <q-card>
                     <q-card-section>
                         <div class="text-grey-8">{{$t('createVulnerabilityCategories')}}</div>
                     </q-card-section>
@@ -561,7 +542,6 @@
                                     :error-message="errors.vulnCat"
                                     @keyup.enter="createVulnerabilityCategory"
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                             </q-item>
@@ -577,7 +557,6 @@
                                     emit-value
                                     map-options
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                                 <q-item-section>
@@ -588,7 +567,6 @@
                                     emit-value
                                     map-options
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                                 <q-item-section>
@@ -605,7 +583,7 @@
                         </div>
 
                         <div v-if="!editCategory" class="col-md-6 col-12">
-                            <q-card flat bordered v-if="vulnCategories.length > 0" class="bg-grey-1">
+                            <q-card flat bordered v-if="vulnCategories.length > 0">
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('listOfCategories')}}</div>
                                     <q-space />
@@ -621,7 +599,6 @@
                                             v-model="vulnCat.name"
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             />
                                         </q-item-section>
                                         <q-item-section>
@@ -632,7 +609,6 @@
                                             map-options
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             />
                                         </q-item-section>
                                         <q-item-section>
@@ -643,7 +619,6 @@
                                             map-options
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             />
                                         </q-item-section>
                                         <q-item-section>
@@ -657,7 +632,7 @@
                             </q-card>
                         </div>
                         <div v-else class="col-md-6 col-12">
-                            <q-card flat bordered class="bg-grey-1">
+                            <q-card flat bordered>
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('editCategories')}}</div>
                             </q-toolbar>
@@ -673,7 +648,6 @@
                                                 :label="$t('name')"
                                                 v-model="vulnCat.name"
                                                 outlined
-                                                bg-color="white"
                                                 />
                                             </q-item-section>
                                             <q-item-section>
@@ -684,7 +658,6 @@
                                                 emit-value
                                                 map-options
                                                 outlined
-                                                bg-color="white"
                                                 />
                                             </q-item-section>
                                             <q-item-section>
@@ -695,7 +668,6 @@
                                                 emit-value
                                                 map-options
                                                 outlined
-                                                bg-color="white"
                                                 />
                                             </q-item-section>
                                             <q-item-section>
@@ -722,7 +694,7 @@
 
             <!-- CUSTOM FIELDS -->
             <q-tab-panel name="custom-fields">
-                <q-card class="bg-grey-1">
+                <q-card>
                     <q-card-section>
                         <div class="text-grey-8">{{$t('createAndManageCustomFields')}}</div>
                     </q-card-section>
@@ -737,7 +709,6 @@
                                 map-options
                                 @input="newCustomField.displaySub = ''"
                                 outlined dense
-                                bg-color="white"
                                 />
                             </q-item-section>
                             <q-item-section class="col-md-3">
@@ -754,7 +725,6 @@
                                 stack-label
                                 clearable
                                 outlined dense
-                                bg-color="white"
                                 />
                                 <q-select
                                 v-if="newCustomField.display === 'section'"
@@ -769,7 +739,6 @@
                                 stack-label
                                 clearable
                                 outlined dense
-                                bg-color="white"
                                 />
                             </q-item-section>
                         </q-item>
@@ -788,7 +757,6 @@
                                         lazy-rules="ondemand"
                                         hide-bottom-space
                                         outlined dense
-                                        bg-color="white"
                                         >
                                             <template v-slot:selected-item="scope">
                                                 <q-icon :name="scope.opt.icon" />
@@ -824,7 +792,6 @@
                                         lazy-rules="ondemand"
                                         hide-bottom-space
                                         outlined dense
-                                        bg-color="white"
                                         />
                                     </q-item-section>
                                 </q-item>
@@ -836,7 +803,6 @@
                                         clearable
                                         @keyup.enter="createCustomField"
                                         outlined dense
-                                        bg-color="white"
                                         />
                                     </q-item-section>
                                 </q-item>
@@ -847,7 +813,6 @@
                                         v-model="newCustomField.size"
                                         :options="[1,2,3,4,5,6,7,8,9,10,11,12]"
                                         outlined dense
-                                        bg-color="white"
                                         />
                                     </q-item-section>
        
@@ -857,7 +822,6 @@
                                         v-model="newCustomField.offset"
                                         :options="[0,1,2,3,4,5,6,7,8,9,10,11,12]"
                                         outlined dense
-                                        bg-color="white"
                                         />
                                     </q-item-section>
                                 </q-item>
@@ -883,13 +847,12 @@
                                         map-options 
                                         options-sanitize
                                         outlined dense
-                                        bg-color="white"
                                         />
                                     </q-item-section>
                                 </q-item>
                                 <q-item v-if="newCustomFieldLangOptions.length > 0">
                                     <q-item-section>
-                                        <q-list bordered separator dense class="bg-white">
+                                        <q-list bordered separator dense>
                                             <q-item v-for="(option,idx) of newCustomFieldLangOptions" :key="idx">
                                                 <q-item-section>
                                                     {{option.value}}
@@ -907,7 +870,6 @@
                                         :label="$t('addOption')"
                                         v-model="newCustomOption"
                                         outlined dense
-                                        bg-color="white"
                                         @keyup.enter="addCustomFieldOption(newCustomField.options)"
                                         />
                                     </q-item-section>
@@ -936,7 +898,6 @@
                         map-options 
                         options-sanitize
                         outlined
-                        bg-color="white"
                         class="col-md-2 col-12"
                         />
                     </q-card-section>
@@ -956,7 +917,6 @@
                                                     v-model="field.label"
                                                     clearable
                                                     outlined dense
-                                                    bg-color="white"
                                                     />
                                                 </q-item-section>
                                             </q-item>
@@ -968,7 +928,6 @@
                                                     clearable
                                                     @clear="field.description = ''"
                                                     outlined dense
-                                                    bg-color="white"
                                                     />
                                                 </q-item-section>
                                             </q-item>
@@ -979,7 +938,6 @@
                                                     v-model="field.size"
                                                     :options="[1,2,3,4,5,6,7,8,9,10,11,12]"
                                                     outlined dense
-                                                    bg-color="white"
                                                     />
                                                 </q-item-section>
                                                 <q-item-section>
@@ -988,7 +946,6 @@
                                                     v-model="field.offset"
                                                     :options="[0,1,2,3,4,5,6,7,8,9,10,11,12]"
                                                     outlined dense
-                                                    bg-color="white"
                                                     />
                                                 </q-item-section>
                                             </q-item>
@@ -998,13 +955,12 @@
                                                     :label="$t('required')"
                                                     v-model="field.required"
                                                     outlined dense
-                                                    bg-color="white"
                                                     />
                                                 </q-item-section>
                                             </q-item>
                                             <q-item v-if="['select', 'select-multiple', 'checkbox', 'radio'].includes(field.fieldType)">
                                                 <q-item-section>
-                                                    <q-list bordered separator dense class="bg-white">
+                                                    <q-list bordered separator dense>
                                                         <q-item v-for="(option,idx) of getFieldLangOptions(field.options)" :key="idx">
                                                             <q-item-section>
                                                                 {{option.value}}
@@ -1022,7 +978,6 @@
                                                     :label="$t('addOption')"
                                                     v-model="newCustomOption"
                                                     outlined dense
-                                                    bg-color="white"
                                                     @keyup.enter="addCustomFieldOption(field.options)"
                                                     />
                                                 </q-item-section>
@@ -1063,7 +1018,6 @@
                                     :hint="field.description"
                                     hide-bottom-space
                                     outlined
-                                    bg-color="white"
                                     >
                                         <template v-slot:label>
                                             {{field.label}} <span v-if="field.required" class="text-red">*</span>
@@ -1078,7 +1032,6 @@
                                     :hint="field.description"
                                     hide-bottom-space
                                     outlined
-                                    bg-color="white"
                                     >
                                         <template v-slot:append>
                                             <q-icon name="event" class="cursor-pointer">
@@ -1105,7 +1058,6 @@
                                     clearable
                                     options-sanitize
                                     outlined 
-                                    bg-color="white"
                                     >
                                         <template v-slot:label>
                                             {{field.label}} <span v-if="field.required" class="text-red">*</span>
@@ -1128,7 +1080,6 @@
                                     clearable
                                     options-sanitize
                                     outlined 
-                                    bg-color="white"
                                     >
                                         <template v-slot:label>
                                             {{field.label}} <span v-if="field.required" class="text-red">*</span>
@@ -1154,7 +1105,6 @@
                                     :hint="field.description"
                                     hide-bottom-space
                                     outlined 
-                                    bg-color="white"
                                     >
                                         <template v-slot:control>
                                             <q-option-group
@@ -1175,7 +1125,6 @@
                                     :hint="field.description"
                                     hide-bottom-space
                                     outlined 
-                                    bg-color="white"
                                     >
                                         <template v-slot:control>
                                             <q-option-group
@@ -1202,7 +1151,7 @@
 
             <!-- SECTIONS -->
             <q-tab-panel name="custom-sections">
-                <q-card class="bg-grey-1">
+                <q-card>
                     <q-card-section>
                         <div class="text-grey-8">{{$t('createCustomSections')}}</div>
                     </q-card-section>
@@ -1219,7 +1168,6 @@
                                     hide-bottom-space
                                     @keyup.enter="createSection"
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                                 <q-item-section>
@@ -1232,7 +1180,6 @@
                                     hide-bottom-space
                                     @keyup.enter="createSection"
                                     outlined
-                                    bg-color="white"
                                     />
                                 </q-item-section>
                                 <q-item-section>
@@ -1241,7 +1188,6 @@
                                     v-model="newSection.icon"
                                     @keyup.enter="createSection"
                                     outlined
-                                    bg-color="white"
                                     >
                                         <template v-slot:append>
                                             <q-avatar>
@@ -1257,7 +1203,7 @@
                         </div>
 
                         <div v-if="!editSection" class="col-md-6">
-                            <q-card flat bordered v-if="sections.length > 0" class="bg-grey-1">
+                            <q-card flat bordered v-if="sections.length > 0">
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('listOfSections')}}</div>
                                     <q-space />
@@ -1274,7 +1220,6 @@
                                             v-model="section.name"
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             />
                                         </q-item-section>
                                         <q-item-section>
@@ -1283,7 +1228,6 @@
                                             v-model="section.field"
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             />
                                         </q-item-section>
                                         <q-item-section>
@@ -1293,7 +1237,6 @@
                                             v-model="section.icon"
                                             readonly
                                             outlined
-                                            bg-color="white"
                                             >
                                                 <template v-slot:append>
                                                     <q-avatar>
@@ -1307,7 +1250,7 @@
                             </q-card>
                         </div>
                         <div v-else class="col-md-6">
-                            <q-card flat bordered class="bg-grey-1">
+                            <q-card flat bordered>
                                 <q-toolbar>
                                     <div class="text-grey-8">{{$t('editSections')}}</div>
                                 </q-toolbar>
@@ -1324,7 +1267,6 @@
                                                     :label="$t('name')"
                                                     v-model="section.name"
                                                     outlined
-                                                    bg-color="white"
                                                     />
                                                 </q-item-section>
                                                 <q-item-section>
@@ -1332,7 +1274,6 @@
                                                     :label="$t('field')"
                                                     v-model="section.field"
                                                     outlined
-                                                    bg-color="white"
                                                     />
                                                 </q-item-section>
                                                 <q-item-section>
@@ -1341,7 +1282,6 @@
                                                     stack-label
                                                     v-model="section.icon"
                                                     outlined
-                                                    bg-color="white"
                                                     >
                                                         <template v-slot:append>
                                                             <q-avatar>

--- a/frontend/src/pages/data/custom/custom.html
+++ b/frontend/src/pages/data/custom/custom.html
@@ -1,6 +1,6 @@
 <div>
 
-    <q-tabs v-model="selectedTab" no-caps align="left" indicator-color="primary" active-bg-color="grey-3" class="bg-white full-width">
+    <q-tabs v-model="selectedTab" no-caps align="left" indicator-color="primary" :active-bg-color="this.$q.dark.isActive ? '' : 'grey-3'" :class="'full-width' + (this.$q.dark.isActive ? '' : ' bg-white')">
         <q-tab name="languages" default :label="$t('languages')" />
         <q-tab name="audit-types" :label="$t('auditTypes')" />
         <q-tab name="vulnerability-types" :label="$t('vulnerabilityTypes')" />
@@ -886,7 +886,7 @@
                 </q-card>
 
                 <!-- Preview -->
-                <q-card class="q-mt-md bg-grey-1" v-if="canDisplayCustomFields()">
+                <q-card class="q-mt-md" v-if="canDisplayCustomFields()">
                     <q-card-section class="row">
                         <q-select 
                         v-model="cfLocale"
@@ -908,7 +908,7 @@
                                 <q-item-section avatar v-if="UserService.isAllowed('custom-fields:update')">
                                     <q-btn flat color="grey" icon="mdi-arrow-split-horizontal" class="handle" dense size="sm" />
                                     <q-btn flat color="primary" icon="mdi-pencil" dense size="sm">
-                                        <q-menu content-style="width: 300px" anchor="top left" self="top end" content-class="bg-grey-1">
+                                        <q-menu content-style="width: 300px" anchor="top left" self="top end">
                                             
                                             <q-item v-if="field.fieldType !== 'space'">
                                                 <q-item-section>

--- a/frontend/src/pages/data/templates/templates.html
+++ b/frontend/src/pages/data/templates/templates.html
@@ -3,8 +3,6 @@
     <div class="col-md-10 col-12 offset-md-1 q-mt-md">
         <q-table
             class="sticky-header-table"
-            card-class="bg-grey-1"
-            table-header-class="bg-grey-1"
             :columns="dtHeaders"
             :data="templates"
             :filter="search"
@@ -36,7 +34,6 @@
                         v-model="search.name"
                         clearable
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 50%">
@@ -47,7 +44,6 @@
                         v-model="search.ext"
                         clearable
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td></q-td>
@@ -90,7 +86,7 @@
 </div>
 
 <q-dialog ref="createModal" persistent @hide="cleanCurrentTemplate()">
-    <q-card style="width:800px" class="bg-grey-1">
+    <q-card style="width:800px">
         <q-bar class="bg-primary text-white">
             <div class="q-toolbar-title">
                 {{$t('createTemplate')}}
@@ -111,7 +107,6 @@
                 @keyup.enter="createTemplate()"
                 v-model="currentTemplate.name" 
                 outlined
-                bg-color="white"
                 />
                 
                 <q-field class="col-md-12 col-12" no-error-icon borderless :error="!!errors.file" :error-message="errors.file">
@@ -138,7 +133,7 @@
 </q-dialog>
 
 <q-dialog ref="editModal" persistent @hide="cleanCurrentTemplate()">
-    <q-card style="width:800px" class="bg-grey-1">
+    <q-card style="width:800px">
         <q-bar class="bg-primary text-white">
             <div class="q-toolbar-title">
                 {{$t('editTemplate')}}
@@ -159,7 +154,6 @@
                 @keyup.enter="updateTemplate()"
                 v-model="currentTemplate.name" 
                 outlined
-                bg-color="white"
                 />
                 
                 <q-field class="col-md-12 col-12" no-error-icon borderless :error="!!errors.file" :error-message="errors.file">

--- a/frontend/src/pages/profile/profile.html
+++ b/frontend/src/pages/profile/profile.html
@@ -1,7 +1,7 @@
 <div>
     <div class="row">
         <div class="col-md-8 col-12 offset-md-2 q-mt-md">
-            <q-card class="bg-grey-1">
+            <q-card>
                 <q-card-section class="q-py-xs bg-blue-grey-5 text-white">
                     <div class="text-h6">{{$t('updateUserInformation')}}</div>
                 </q-card-section>
@@ -22,8 +22,7 @@
                                 stack-label 
                                 :error="!!errors.username"
                                 :error-message="errors.username" 
-                                outlined
-                                bg-color="white"
+                                outlined                                
                                 />
                             </q-item-section>
                         </q-item>
@@ -35,8 +34,7 @@
                                 stack-label
                                 :error="!!errors.firstname"
                                 :error-message="errors.firstname"
-                                outlined
-                                bg-color="white"
+                                outlined                                
                                 />
                             </q-item-section>
                         </q-item>
@@ -48,8 +46,7 @@
                                 stack-label 
                                 :error="!!errors.lastname"
                                 :error-message="errors.lastname"
-                                outlined
-                                bg-color="white"
+                                outlined                                
                                 />
                             </q-item-section>
                         </q-item>
@@ -85,8 +82,7 @@
                                     stack-label 
                                     type="password"
                                     clearable
-                                    outlined
-                                    bg-color="white"
+                                    outlined                                    
                                     />
                                     <q-input 
                                     class="col-md-6 col-6 q-pl-sm" 
@@ -94,8 +90,7 @@
                                     :label="$t('confirmPassword')" 
                                     stack-label 
                                     type="password"
-                                    outlined
-                                    bg-color="white"
+                                    outlined                                    
                                     clearable
                                     />
                                 </q-field>
@@ -111,8 +106,7 @@
                                 :error="!!errors.currentPassword" 
                                 :error-message="errors.currentPassword"
                                 @keyup.enter="updateProfile"
-                                outlined
-                                bg-color="white"
+                                outlined                                
                                 >
                                     <template v-slot:append>
                                         <q-btn :label="$t('btn.update')" unelevated color="secondary" @click="updateProfile" />

--- a/frontend/src/pages/profile/profile.html
+++ b/frontend/src/pages/profile/profile.html
@@ -57,7 +57,6 @@
                                 label="Email" 
                                 stack-label 
                                 outlined
-                                bg-color="white"
                                 />
                             </q-item-section>
                         </q-item>
@@ -68,7 +67,6 @@
                                 label="Phone" 
                                 stack-label 
                                 outlined
-                                bg-color="white"
                                 />
                             </q-item-section>
                         </q-item>
@@ -165,7 +163,6 @@
                                     placeholder="Enter 6-digit code"
                                     @keyup.enter="setupTotp"
                                     outlined
-                                    bg-color="white"
                                     >
                                         <template v-slot:append>
                                             <q-btn label="Enable" unelevated color="secondary" @click="setupTotp" />
@@ -199,7 +196,6 @@
                                     placeholder="Enter 6-digit code"
                                     @keyup.enter="cancelTotp"
                                     outlined
-                                    bg-color="white"
                                     >
                                         <template v-slot:append>
                                             <q-btn label="Disable" unelevated color="negative" @click="cancelTotp" />

--- a/frontend/src/pages/vulnerabilities/vulnerabilities.html
+++ b/frontend/src/pages/vulnerabilities/vulnerabilities.html
@@ -6,8 +6,6 @@
     <div v-else class="col-md-8 col-12 offset-md-2 q-mt-md">
         <q-table
             class="sticky-header-table"
-            card-class="bg-grey-1"
-            table-header-class="bg-grey-1"
             :columns="dtHeaders"
             :data="computedVulnerabilities"
             :filter="search"
@@ -31,7 +29,6 @@
                 emit-value
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
                 <q-toggle :label="$t('btn.valid')" v-model="search.valid" :true-value=0 />
                 <q-toggle :label="$t('btn.new')" color="light-blue" v-model="search.new" :true-value=1 />
@@ -80,7 +77,6 @@
                         clearable
                         autofocus
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 20%">
@@ -93,7 +89,6 @@
                         :options="vulnCategoriesOptions"
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td style="width: 20%">
@@ -106,7 +101,6 @@
                         :options="vulnTypeOptions"
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                     </q-td>
                     <q-td></q-td>
@@ -165,7 +159,7 @@
 </div>
 
 <q-dialog v-if="languages.length > 0" ref="createModal" maximized position="right" persistent @hide="cleanCurrentVulnerability()">
-    <q-card :style="($q.screen.gt.lg)?'width: 50vw':'width:1000px'" class="bg-grey-1">
+    <q-card :style="($q.screen.gt.lg)?'width: 50vw':'width:1000px'">
         <q-bar class="bg-primary text-white">
             <div class="q-toolbar-title">
                 <span v-if="currentCategory">{{$t('addVulnerability')}} ({{currentCategory.name}})</span>
@@ -188,7 +182,6 @@
                 @keyup.enter="createVulnerability()"
                 v-model="currentVulnerability.details[currentDetailsIndex].title"
                 outlined
-                bg-color="white"
                 />
                 <q-select 
                 class="col-md-2"
@@ -201,7 +194,6 @@
                 map-options
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
                 <q-select
                 :label="$t('language')"
@@ -215,7 +207,6 @@
                 emit-value
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
             </div>
         </q-card-section>
@@ -260,7 +251,6 @@
                 emit-value
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
                 <q-select
                 :label="$t('remediationPriority')"
@@ -272,7 +262,6 @@
                 emit-value
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
             </div>
         </q-card-section>
@@ -306,7 +295,7 @@
 </q-dialog>
 
 <q-dialog v-if="languages.length > 0" ref="editModal" maximized position="right" :persistent="UserService.isAllowed('vulnerabilities:update')" @hide="cleanCurrentVulnerability()">
-    <q-card :style="($q.screen.gt.lg)?'width: 50vw':'width:1000px'" class="bg-grey-1">
+    <q-card :style="($q.screen.gt.lg)?'width: 50vw':'width:1000px'">
         <q-bar class="bg-primary text-white">
             <div class="q-toolbar-title">
                 <span v-if="currentVulnerability.category">{{$t('editVulnerability')}} ({{currentVulnerability.category}})</span>
@@ -355,7 +344,6 @@
                 @keyup.enter="updateVulnerability()"
                 v-model="currentVulnerability.details[currentDetailsIndex].title"
                 outlined
-                bg-color="white"
                 />
                 <q-select 
                 class="col-md-2"
@@ -368,7 +356,6 @@
                 map-options
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
                 <q-select
                 :label="$t('language')"
@@ -382,7 +369,6 @@
                 emit-value
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
             </div>
         </q-card-section>
@@ -427,7 +413,6 @@
                 emit-value
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
                 <q-select
                 :label="$t('remediationPriority')"
@@ -439,7 +424,6 @@
                 emit-value
                 options-sanitize
                 outlined
-                bg-color="white"
                 />
             </div>
         </q-card-section>
@@ -504,7 +488,6 @@
                         v-model="currentVulnerability.details[currentDetailsIndex].title" 
                         readonly
                         outlined
-                        bg-color="white"
                         />
                         <q-select 
                         class="col-md-2"
@@ -517,7 +500,6 @@
                         map-options
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                         <q-select
                         :label="$t('language')"
@@ -532,7 +514,6 @@
                         readonly
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                     </q-card-section>
                     <q-card-section>
@@ -573,7 +554,6 @@
                         emit-value
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                         <q-select
                         :label="$t('remediationPriority')"
@@ -585,7 +565,6 @@
                         emit-value
                         options-sanitize
                         outlined
-                        bg-color="white"
                         />
                     </q-card-section>
                     <q-card-section>
@@ -637,7 +616,6 @@
                                 v-model="update.title"
                                 readonly
                                 outlined
-                                bg-color="white"
                                 />
                                 <q-select 
                                 class="col-md-2"
@@ -666,7 +644,6 @@
                                 readonly
                                 options-sanitize
                                 outlined
-                                bg-color="white"
                                 />
                             </q-card-section>
                             <q-card-section>
@@ -798,7 +775,7 @@
 </q-dialog>
 
 <q-dialog persistent ref="mergeModal">
-    <q-card style="width: 1000px; max-width: 1000px; height: 60vh" class="bg-grey-1">
+    <q-card style="width: 1000px; max-width: 1000px; height: 60vh">
         <q-bar class="bg-primary text-white">
             <span>{{$t('mergeVulnerabilities')}}</span>
             <q-space />
@@ -822,7 +799,6 @@
                     @input="mergeVulnLeft = ''"
                     options-sanitize
                     outlined
-                    bg-color="white"
                     />
                 </q-card-section>
                 <q-card-section class="card-section-merge">
@@ -854,7 +830,6 @@
                     @input="mergeVulnRight = ''"
                     options-sanitize
                     outlined
-                    bg-color="white"
                     />
                 </q-card-section>
                 <q-card-section class="card-section-merge">


### PR DESCRIPTION
Added a darkmode and a switch. The switch is inside the dropdown-menu when clicking on your username.

On the main audit-page it looks like this (example, applies to all pages!):
![pic1](https://user-images.githubusercontent.com/24229904/148682007-331df02d-d481-4fa9-8d13-f2e05830bf75.png)

It uses the [darkmode of `quasar`](https://quasar.dev/style/dark-mode).
The selected mode will be stored inside the `localStorage`.

**Warning:** Because there are many static colors using the `bg-white`- or `bg-grey-1`-classes, I decided to remove them to implement this easily. If I preseved those colors, I would need to check everywhere, if the darkmode is activated, which creates a lot of overhead. In my opinion, this looks still nice, but if you want to keep those static colors, let me know, because this cannot be merged then.

Also let me know, if there is a component or page missing.