### PR TITLE
WebSocket JWT-authentication

### DIFF
--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -73,7 +73,9 @@ var builtInRoles = {
             // Custom Fields
             'custom-fields:read',
             // Settings
-            'settings:read-public'
+            'settings:read-public',
+            // WebSocket
+            'websocket:connect'
         ]
     },
     admin: {

--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -119,10 +119,19 @@ class ACL {
         return $role.inherits.some(role => this.isAllowed(role, permission))
     }
 
-    hasPermission (permission) {
+    hasPermission (permission, directToken) {
         var Response = require('./httpResponse')
         var jwt = require('jsonwebtoken')
 
+        if(directToken == null) {
+            // direct verification - not as middleware
+            jwt.verify(directToken, jwtSecret, (err, decoded) => {
+                if (err) {
+                    return false;
+                }              
+                return permission === "validtoken" || this.isAllowed(decoded.role, permission);
+            })
+        }
         return (req, res, next) => {
             if (!req.cookies['token']) {
                 Response.Unauthorized(res, 'No token provided')

--- a/frontend/src/boot/socketio.js
+++ b/frontend/src/boot/socketio.js
@@ -1,5 +1,21 @@
 import io from 'socket.io-client'
 
+const exportedObject = {
+    io: null,
+    connect: function() {
+        if(this.io != null) {
+            return;
+        }
+        this.io = io(`${window.location.protocol}//${window.location.hostname}:${process.env.API_PORT}`);
+    },
+    disconnect: function() {
+        if(this.io != null) {
+            this.io.disconnect();
+            this.io = null;
+        }
+    }
+};
+
 export default ({ Vue }) => {
-    Vue.prototype.$socket = io(`${window.location.protocol}//${window.location.hostname}:${process.env.API_PORT}`);
+    Vue.prototype.$socket = exportedObject;
 }  

--- a/frontend/src/pages/audits/edit/findings/add/add.js
+++ b/frontend/src/pages/audits/edit/findings/add/add.js
@@ -70,7 +70,7 @@ export default {
         this.getVulnerabilities();
         this.getVulnerabilityCategories()
 
-        this.$socket.emit('menu', {menu: 'addFindings', room: this.auditId});
+        this.$socket.io.emit('menu', {menu: 'addFindings', room: this.auditId});
     },
 
     computed: {

--- a/frontend/src/pages/audits/edit/findings/edit/edit.js
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.js
@@ -45,7 +45,7 @@ export default {
         this.getFinding();
         this.getVulnTypes();
 
-        this.$socket.emit('menu', {menu: 'editFinding', finding: this.findingId, room: this.auditId});
+        this.$socket.io.emit('menu', {menu: 'editFinding', finding: this.findingId, room: this.auditId});
 
         // save on ctrl+s
         document.addEventListener('keydown', this._listener, false);

--- a/frontend/src/pages/audits/edit/general/general.js
+++ b/frontend/src/pages/audits/edit/general/general.js
@@ -84,7 +84,7 @@ export default {
         this.getLanguages();
         this.getAuditTypes();
 
-        this.$socket.emit('menu', {menu: 'general', room: this.auditId});
+        this.$socket.io.emit('menu', {menu: 'general', room: this.auditId});
 
         // save on ctrl+s
         // var lastSave = 0;

--- a/frontend/src/pages/audits/edit/index.vue
+++ b/frontend/src/pages/audits/edit/index.vue
@@ -273,8 +273,8 @@ export default {
 
 		destroyed: function() {
 			if (!this.loading) {
-				this.$socket.emit('leave', {username: UserService.user.username, room: this.auditId});
-				this.$socket.off()
+				this.$socket.io.emit('leave', {username: UserService.user.username, room: this.auditId});
+				this.$socket.io.off()
 			}
 		},
 
@@ -359,8 +359,8 @@ export default {
 
 			// Sockets handle
 			handleSocket: function() {
-				this.$socket.emit('join', {username: UserService.user.username, room: this.auditId});
-				this.$socket.on('roomUsers', (users) => {
+				this.$socket.io.emit('join', {username: UserService.user.username, room: this.auditId});
+				this.$socket.io.on('roomUsers', (users) => {
 					var userIndex = 0;
 					this.users = users.map((user,index) => {
 						if (user.username === UserService.user.username) {
@@ -372,10 +372,10 @@ export default {
 					});
 					this.users.unshift(this.users.splice(userIndex, 1)[0]);
 				})
-				this.$socket.on('updateUsers', () => {
-					this.$socket.emit('updateUsers', {room: this.auditId})
+				this.$socket.io.on('updateUsers', () => {
+					this.$socket.io.emit('updateUsers', {room: this.auditId})
 				})
-				this.$socket.on('updateAudit', () => {
+				this.$socket.io.on('updateAudit', () => {
 					this.getAudit();
 				})
 			},

--- a/frontend/src/pages/audits/edit/network/network.js
+++ b/frontend/src/pages/audits/edit/network/network.js
@@ -51,7 +51,7 @@ export default {
         this.auditId = this.$route.params.auditId;
         this.getAuditNetwork();
         
-        this.$socket.emit('menu', {menu: 'network', room: this.auditId});
+        this.$socket.io.emit('menu', {menu: 'network', room: this.auditId});
 
         // save on ctrl+s
         var lastSave = 0;

--- a/frontend/src/pages/audits/edit/sections/sections.js
+++ b/frontend/src/pages/audits/edit/sections/sections.js
@@ -43,7 +43,7 @@ export default {
         this.sectionId = this.$route.params.sectionId;
         this.getSection();
 
-        this.$socket.emit('menu', {menu: 'editSection', section: this.sectionId, room: this.auditId});
+        this.$socket.io.emit('menu', {menu: 'editSection', section: this.sectionId, room: this.auditId});
 
         // save on ctrl+s
         document.addEventListener('keydown', this._listener, false)

--- a/frontend/src/pages/audits/index.vue
+++ b/frontend/src/pages/audits/index.vue
@@ -10,6 +10,9 @@ import Breadcrumb from 'components/breadcrumb'
 export default {
     components: {
         Breadcrumb
+    },
+    mounted: function() {
+        this.$socket.connect();
     }
 }
 </script>

--- a/frontend/src/services/user.js
+++ b/frontend/src/services/user.js
@@ -35,6 +35,8 @@ export default {
             .then((response) => {
                 var token = response.data.datas.token;
                 this.user = jwtDecode(token);
+                Vue.prototype.$socket.disconnect();
+                Vue.prototype.$socket.connect();
                 resolve()
             })
             .catch(err => {


### PR DESCRIPTION
Use authentication on the websocket using the JWT.

For that some changes were required:
* ACL needs an option to check JWT's and not returning a middleware
  * Optional parameter which toggles between (non-)middleware-mode
* Socket on frontend needs to be able to reconnect when the token refreshes
  * For that, the socket on the `Vue.prototype` inside a new object -> `io` is reachable inside that object
  * Socket gets connected initially when the `index.vue` of the audit-page is mounted
  * 
At the moment there is no direct leak of information because users need to join the correct group, but if the websocket has more features in the future it should be protected.