### PR TITLE
LDAP Login

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pwndoc-backend",
       "version": "0.0.1",
       "dependencies": {
-        "angular-expressions": "^1.0.1",
+        "angular-expressions": "^1.1.2",
         "bcrypt": "^3.0.6",
         "body-parser": "^1.17.1",
         "cookie-parser": "^1.4.5",
@@ -24,6 +24,7 @@
         "js-yaml": "^3.13.1",
         "jsonwebtoken": "^8.1.0",
         "jszip": "^2.6.1",
+        "ldapjs": "^2.3.1",
         "lodash": "^4.17.15",
         "mongoose": "^5.7.7",
         "otpauth": "^7.0.6",
@@ -4038,6 +4039,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "node_modules/accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -4099,9 +4105,9 @@
       }
     },
     "node_modules/angular-expressions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/angular-expressions/-/angular-expressions-1.0.1.tgz",
-      "integrity": "sha512-rMBuCZzxKNO706Bo5TarLowMXmScOR78fnSuWQSYaAAF23HsLt0gAVWo4PJtRtGBsRAV8pJjXUOGjgkMNlt56g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/angular-expressions/-/angular-expressions-1.1.4.tgz",
+      "integrity": "sha512-c+dUX5GxcFPGmWG/1deibXht5WVnr9rMkPiWG6i1ErUU4Ua+LzY9nbEyBkfKUPOZFuo1MDO6OkxfHtQBJZDnnA=="
     },
     "node_modules/ansi-align": {
       "version": "2.0.0",
@@ -4281,7 +4287,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -4290,7 +4295,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -4456,6 +4460,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "node_modules/backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "dependencies": {
+        "precond": "0.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -6399,7 +6414,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
       ]
@@ -8345,6 +8359,35 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ldap-filter": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz",
+      "integrity": "sha1-KxTGiiqdQQTb28kQocqF/Riel5c=",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ldapjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.3.1.tgz",
+      "integrity": "sha512-kf0tHHLrpwKaBAQOhYHXgdeh2PkFuCCxWgLb1MRn67ZQVo787D2pij3mmHVZx193GIdM8xcfi8HF6AIYYnj0fQ==",
+      "dependencies": {
+        "abstract-logging": "^2.0.0",
+        "asn1": "^0.2.4",
+        "assert-plus": "^1.0.0",
+        "backoff": "^2.5.0",
+        "ldap-filter": "^0.3.3",
+        "once": "^1.4.0",
+        "vasync": "^2.2.0",
+        "verror": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/leven": {
@@ -14418,6 +14461,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -16822,11 +16873,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vasync": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-2.2.1.tgz",
+      "integrity": "sha512-Hq72JaTpcTFdWiNA4Y22Amej2GH3BFmBaKPPlDZ4/oC8HNn2ISHLkFrJU4Ds8R3jcUi7oo5Y9jcMHKjES+N9wQ==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "verror": "1.10.0"
+      }
+    },
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
@@ -21054,6 +21115,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -21103,9 +21169,9 @@
       }
     },
     "angular-expressions": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/angular-expressions/-/angular-expressions-1.1.2.tgz",
-      "integrity": "sha512-nTu8idKKtQeUGSY+Wk0x/jhM+m0fnqK7XlYdLmfKLqcrn3TRbkGqxID4pfste3qPJq7zQeliGIlIY3VivC/rpQ=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/angular-expressions/-/angular-expressions-1.1.4.tgz",
+      "integrity": "sha512-c+dUX5GxcFPGmWG/1deibXht5WVnr9rMkPiWG6i1ErUU4Ua+LzY9nbEyBkfKUPOZFuo1MDO6OkxfHtQBJZDnnA=="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -21250,7 +21316,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -21258,8 +21323,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -21398,6 +21462,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -23012,8 +23084,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
       "version": "0.1.8",
@@ -24592,6 +24663,29 @@
       "dev": true,
       "requires": {
         "package-json": "^4.0.0"
+      }
+    },
+    "ldap-filter": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz",
+      "integrity": "sha1-KxTGiiqdQQTb28kQocqF/Riel5c=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "ldapjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.3.1.tgz",
+      "integrity": "sha512-kf0tHHLrpwKaBAQOhYHXgdeh2PkFuCCxWgLb1MRn67ZQVo787D2pij3mmHVZx193GIdM8xcfi8HF6AIYYnj0fQ==",
+      "requires": {
+        "abstract-logging": "^2.0.0",
+        "asn1": "^0.2.4",
+        "assert-plus": "^1.0.0",
+        "backoff": "^2.5.0",
+        "ldap-filter": "^0.3.3",
+        "once": "^1.4.0",
+        "vasync": "^2.2.0",
+        "verror": "^1.8.1"
       }
     },
     "leven": {
@@ -29116,6 +29210,11 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -31129,11 +31228,18 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "vasync": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-2.2.1.tgz",
+      "integrity": "sha512-Hq72JaTpcTFdWiNA4Y22Amej2GH3BFmBaKPPlDZ4/oC8HNn2ISHLkFrJU4Ds8R3jcUi7oo5Y9jcMHKjES+N9wQ==",
+      "requires": {
+        "verror": "1.10.0"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "js-yaml": "^3.13.1",
     "jsonwebtoken": "^8.1.0",
     "jszip": "^2.6.1",
+    "ldapjs": "^2.3.1",
     "lodash": "^4.17.15",
     "mongoose": "^5.7.7",
     "otpauth": "^7.0.6",

--- a/backend/src/config/config.json
+++ b/backend/src/config/config.json
@@ -10,7 +10,9 @@
         "ldap": {
             "ldapEnabled": false,
             "address": "ldaps://someserver:636",
-            "userDN": "uid=%u,ou=Users,dc=example,dc=org"
+            "userDN": "uid=%u,ou=Users,dc=example,dc=org",
+            "mailAttr": "mail",
+            "displayNameAttr": "displayName"
         }
     },
     "prod": {
@@ -24,7 +26,9 @@
         "ldap": {
             "ldapEnabled": false,
             "address": "ldaps://someserver:636",
-            "userDN": "uid=%u,ou=Users,dc=example,dc=org"
+            "userDN": "uid=%u,ou=Users,dc=example,dc=org",
+            "mailAttr": "mail",
+            "displayNameAttr": "displayName"
         }
     },
     "test": {
@@ -38,7 +42,9 @@
         "ldap": {
             "ldapEnabled": false,
             "address": "ldaps://someserver:636",
-            "userDN": "uid=%u,ou=Users,dc=example,dc=org"
+            "userDN": "uid=%u,ou=Users,dc=example,dc=org",
+            "mailAttr": "mail",
+            "displayNameAttr": "displayName"
         }
     }
 }

--- a/backend/src/config/config.json
+++ b/backend/src/config/config.json
@@ -6,6 +6,11 @@
             "name": "pwndoc",
             "server": "mongo-pwndoc-dev",
             "port": "27017"
+        },
+        "ldap": {
+            "ldapEnabled": false,
+            "address": "ldaps://someserver:636",
+            "userDN": "uid=%u,ou=Users,dc=example,dc=org"
         }
     },
     "prod": {
@@ -15,6 +20,11 @@
             "name": "pwndoc",
             "server": "mongo-pwndoc",
             "port": "27017"
+        },
+        "ldap": {
+            "ldapEnabled": false,
+            "address": "ldaps://someserver:636",
+            "userDN": "uid=%u,ou=Users,dc=example,dc=org"
         }
     },
     "test": {
@@ -24,6 +34,11 @@
             "name": "pwndoc",
             "server": "mongo-pwndoc-test",
             "port": "27017"
+        },
+        "ldap": {
+            "ldapEnabled": false,
+            "address": "ldaps://someserver:636",
+            "userDN": "uid=%u,ou=Users,dc=example,dc=org"
         }
     }
 }

--- a/backend/src/lib/ldap.js
+++ b/backend/src/lib/ldap.js
@@ -54,6 +54,10 @@ function bind(client, username, password) {
 
 function auth(username, password) {
   return new Promise((resolve, reject) => {
+    if(!username.match(/^[a-zA-Z0-9\.\_\-@]+$/)) {
+      reject({code: 49}); // invalid username
+      return;
+    }
     let client = ldap.createClient({
       url: config[env].ldap.address,
     });

--- a/backend/src/lib/ldap.js
+++ b/backend/src/lib/ldap.js
@@ -52,8 +52,8 @@ function bind(client, username, password) {
   });
 }
 
-module.exports = (username, password) =>
-  new Promise((resolve, reject) => {
+function auth(username, password) {
+  return new Promise((resolve, reject) => {
     let client = ldap.createClient({
       url: config[env].ldap.address,
     });
@@ -70,3 +70,9 @@ module.exports = (username, password) =>
         reject(e);
       });
   });
+}
+
+module.exports = {
+  auth,
+  enabled: config[env].ldap.ldapEnabled,
+};

--- a/backend/src/lib/ldap.js
+++ b/backend/src/lib/ldap.js
@@ -64,7 +64,10 @@ function auth(username, password) {
       .then(() => search(client, username))
       .then((resp) => {
         client.unbind();
-        resolve(resp);
+        resolve({
+          displayName: resp[config[env].ldap.displayNameAttr || "displayName"],
+          mail: resp[config[env].ldap.mailAttr || "mail"],
+        });
       })
       .catch((e) => {
         reject(e);

--- a/backend/src/lib/ldap.js
+++ b/backend/src/lib/ldap.js
@@ -1,0 +1,72 @@
+const env = process.env.NODE_ENV || 'dev'
+const config = require('../config/config.json')
+const ldap = require("ldapjs");
+
+/**
+ * This searches LDAP for an entry based on username
+ * @param {ldapjs.Client} client The client to use
+ * @param {string} username The username to search
+ * @returns {Promise<object>} Promise resolves with the user object
+ */
+function search(client, username) {
+  return new Promise((resolve, reject) => {
+    client.search(
+      config[env].ldap.userDN.replace("%u", username),
+      {},
+      (err, resp) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resp.on("searchEntry", function (entry) {
+          resolve(entry.object);
+        });
+        resp.on("error", function (err) {
+          reject(err);
+        });
+      }
+    );
+  });
+}
+
+/**
+ * This binds the client.
+ * @param {ldapjs.Client} client The client to use
+ * @param {string} username The username to bind
+ * @param {string} password The password to use on binding process
+ * @returns {Promise} Promise resolves when binding was good.
+ */
+function bind(client, username, password) {
+  return new Promise((resolve, reject) => {
+    client.bind(
+      config[env].ldap.userDN.replace("%u", username),
+      password,
+      (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      }
+    );
+  });
+}
+
+module.exports = (username, password) =>
+  new Promise((resolve, reject) => {
+    let client = ldap.createClient({
+      url: config[env].ldap.address,
+    });
+    client.on("error", function (err) {
+      reject(err);
+    });
+    bind(client, username, password)
+      .then(() => search(client, username))
+      .then((resp) => {
+        client.unbind();
+        resolve(resp);
+      })
+      .catch((e) => {
+        reject(e);
+      });
+  });

--- a/frontend/src/pages/data/collaborators/collaborators.html
+++ b/frontend/src/pages/data/collaborators/collaborators.html
@@ -239,17 +239,22 @@
             
             <q-card-section>
                 <q-input
-                :label="$t('username')+' *'"
-                autofocus
-                class="col-md-12"
-                :error="!!errors.username"
-                :error-message="errors.username"
-                hide-bottom-space
-                @keyup.enter="updateCollab()"
-                v-model="currentCollab.username"
-                outlined
-                bg-color="white"
-                />
+                    :label="$t('username')+' *'"
+                    autofocus
+                    class="col-md-12"
+                    :error="!!errors.username"
+                    :error-message="errors.username"
+                    hide-bottom-space
+                    @keyup.enter="updateCollab()"
+                    v-model="currentCollab.username"
+                    outlined
+                    bg-color="white"
+                    :disable="currentCollab.ldapEnabled"
+                >
+                    <template v-slot:append v-if="currentCollab.ldapEnabled">
+                        <q-chip square :label="$t('LDAP')" class="text-white" color="purple" />
+                    </template>
+                </q-input>
             </q-card-section>
             <q-card-section>
                 <q-input
@@ -262,6 +267,7 @@
                 v-model="currentCollab.firstname"
                 outlined
                 bg-color="white"
+                :disable="currentCollab.ldapEnabled"
                 />
             </q-card-section>  
             <q-card-section>
@@ -275,6 +281,7 @@
                 v-model="currentCollab.lastname"
                 outlined
                 bg-color="white"
+                :disable="currentCollab.ldapEnabled"
                 />
             </q-card-section>
             <q-card-section>
@@ -286,6 +293,7 @@
                 v-model="currentCollab.email"
                 outlined
                 bg-color="white"
+                :disable="currentCollab.ldapEnabled"
                 />
             </q-card-section>
             <q-card-section>
@@ -311,7 +319,7 @@
                 bg-color="white"
                 />
             </q-card-section>   
-            <q-card-section>
+            <q-card-section v-if="!currentCollab.ldapEnabled">
                 <q-input 
                 v-model="currentCollab.password" 
                 :label="$t('password')" 

--- a/frontend/src/pages/data/collaborators/collaborators.js
+++ b/frontend/src/pages/data/collaborators/collaborators.js
@@ -50,7 +50,8 @@ export default {
                 role: '',
                 email: '',
                 phone: '',
-                totpEnabled: false
+                totpEnabled: false,
+                ldapEnabled: false,
             },
             // Username to identify collab to update
             idUpdate: '',

--- a/frontend/src/pages/profile/profile.html
+++ b/frontend/src/pages/profile/profile.html
@@ -13,6 +13,9 @@
                             <q-item-section side>
                                 <q-chip square :label="user.role" class="text-white" :color="(user.role === 'admin')?'orange':'info'" />
                             </q-item-section>
+                            <q-item-section side v-if="user.ldapEnabled">
+                                <q-chip square :label="$t('LDAP')" class="text-white" color="purple" />
+                            </q-item-section>
                         </q-item>
                         <q-item>
                             <q-item-section>
@@ -24,6 +27,7 @@
                                 :error-message="errors.username" 
                                 outlined
                                 bg-color="white"
+                                :disable="user.ldapEnabled"
                                 />
                             </q-item-section>
                         </q-item>
@@ -37,6 +41,7 @@
                                 :error-message="errors.firstname"
                                 outlined
                                 bg-color="white"
+                                :disable="user.ldapEnabled"
                                 />
                             </q-item-section>
                         </q-item>
@@ -50,6 +55,7 @@
                                 :error-message="errors.lastname"
                                 outlined
                                 bg-color="white"
+                                :disable="user.ldapEnabled"
                                 />
                             </q-item-section>
                         </q-item>
@@ -61,6 +67,7 @@
                                 stack-label 
                                 outlined
                                 bg-color="white"
+                                :disable="user.ldapEnabled"
                                 />
                             </q-item-section>
                         </q-item>
@@ -75,7 +82,7 @@
                                 />
                             </q-item-section>
                         </q-item>
-                        <q-item>
+                        <q-item v-if="!user.ldapEnabled">
                             <q-item-section>
                                 <q-field borderless :error="!!errors.newPassword" :error-message="errors.newPassword">
                                     <q-input 
@@ -101,7 +108,7 @@
                                 </q-field>
                             </q-item-section>
                         </q-item>
-                        <q-item>
+                        <q-item v-if="!user.ldapEnabled">
                             <q-item-section>
                                 <q-input 
                                 v-model="user.currentPassword" 

--- a/frontend/src/pages/profile/profile.html
+++ b/frontend/src/pages/profile/profile.html
@@ -108,7 +108,7 @@
                                 </q-field>
                             </q-item-section>
                         </q-item>
-                        <q-item v-if="!user.ldapEnabled">
+                        <q-item>
                             <q-item-section>
                                 <q-input 
                                 v-model="user.currentPassword" 


### PR DESCRIPTION
I had some code laying around and thought about LDAP-integration in `pwndoc`.

This PR brings a basic LDAP integration. For that, there were some bigger changes on the `getToken()`-function inside the `User`-model. One big change is the use of `async/await` because it makes coding stuff like that in my opinion easier than bigger promise-chains, but let me know if you prefer those.

It does not use an account on the LDAP-server itself to search for users, instead it directly tries to bind with the user which should be logged in. So no extra account is needed!

The function `getToken()` now works like that:
* Select user
* User found?
  * LDAP-integration disabled & User is ldapUser? -> Unauthorized
  * LDAP-integration enabled & User is ldapUser? -> LDAP-Login -> Update local userdata like name or mail -> Authorized
  * Normal bcrypt-authentication -> Authorized
* User not found?
  * LDAP-integration enabled? Test userdata and create new ldapUser -> Authorized
* Is unauthorized?
  *  throw error
* Usual TOTP checks etc.

Also the profile-updates were changed to only allow LDAP-users to change phone and TOTP instead of the name etc.