### PR TITLE
Fix: Correctly reject promise when wrong password on profile (#249)

### DIFF
--- a/frontend/src/boot/axios.js
+++ b/frontend/src/boot/axios.js
@@ -40,6 +40,11 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error)
     }
 
+    // 401 after wrong password on profile
+    if (error.response.status === 401 && originalRequest.url.endsWith('/users/me')) {
+      return Promise.reject(error)
+    }
+
     // **** End of exceptions
 
     // All other 401 calls


### PR DESCRIPTION
This is a fix for issue #249, which resolves a request loop on the profile page.