### PR TITLE
Fix for sortArrayByField when using sorting for CVSS attributes

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -179,6 +179,20 @@ expressions.filters.sortArrayByField = function (input, field, order) {
     return sorted;
 }
 
+// Sort CVSS array by supplied field: {#findings | sortArrayByCVSS: 'identifier':1}{/}
+// order: 1 = ascending, -1 = descending
+expressions.filters.sortArrayByCVSS= function (input, field, order) {
+    //invalid order sort ascending
+    if(order != 1 && order != -1) order = 1;
+    
+    const sorted = input.sort((a,b) => {
+        o = a['cvss'][field] < b['cvss'][field] ? -1 : (a['cvss'][field] > b['cvss'][field] ? 1 : 0)
+        //multiply by order so that if is descending (-1) will reverse the values
+        return o * order;
+    })    
+    return sorted;
+}
+
 // Convert HTML data to Open Office XML format: {@input | convertHTML: 'customStyle'}
 expressions.filters.convertHTML = function(input, style) {
     if (typeof input === 'undefined')

--- a/docs/docxtemplate.md
+++ b/docs/docxtemplate.md
@@ -360,10 +360,3 @@ Convert cvss Criteria to French.
 {cvssObj.AV | criteriaFR} -> Réseau
 >```
 
-### $pageBreakExceptLast
-Creates Page Break
-
-> Use in template document
->```
-{@$pageBreakExceptLast}
->```

--- a/docs/docxtemplate.md
+++ b/docs/docxtemplate.md
@@ -315,6 +315,18 @@ Order can be 1 for ascending, or -1 for descending
 {/}
 >```
 
+### sortArrayByCVSS
+
+Sort CVSS array by supplied CVSS field. 
+Order can be 1 for ascending, or -1 for descending
+
+> Use in template document
+>```
+{#findings | sortArrayByCVSS: 'identifier':1}
+{identifier}
+{/}
+>```
+
 ### count 
 
 Count the number of vulnerabilities by CVSS severity.
@@ -346,4 +358,12 @@ Convert cvss Criteria to French.
 >```
 // Example with cvssObj.AV === 'Network'
 {cvssObj.AV | criteriaFR} -> Réseau
+>```
+
+### $pageBreakExceptLast
+Creates Page Break
+
+> Use in template document
+>```
+{@$pageBreakExceptLast}
 >```


### PR DESCRIPTION
Due to new CVSS design. It is no longer possible to sort over CVSS attributes (e.g. baseSeverity).... sortArrayByCVSS enables sorting over these attributes. For example: {#findings | sortArrayByCVSS: ‘baseMetricScore’: -1}