### PR TITLE
Fix: Remove invalid file name characters of report-name

### DIFF
--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -368,7 +368,7 @@ module.exports = function(app, io) {
                 throw ({fn: 'BadParameters', message: 'Template not defined'})
 
             var reportDoc = await reportGenerator.generateDoc(audit);
-            Response.SendFile(res, `${audit.name}.${audit.template.ext || 'docx'}`, reportDoc);
+            Response.SendFile(res, `${audit.name.replace(/[\\\/:*?"<>|]/g, "")}.${audit.template.ext || 'docx'}`, reportDoc);
         })
         .catch(err => {
             if (err.code === "ENOENT")


### PR DESCRIPTION
This is a fix for the problem mentioned in #276. It removes several characters when sending over the file.