### PR TITLE
Add support for custom API_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,10 @@ services:
       - backend
 
   pwndoc-frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+       - API_PORT: 8443 # https://pwndoc.github.io/pwndoc/#/installation?id=custom-port
     image: yeln4ts/pwndoc:frontend
     container_name: pwndoc-frontend
     restart: always

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,3 +96,27 @@ To restore :
 - Stop containers
 - Replace the current `backend/mongo-data` folder with the backed up one
 - Start containers
+
+
+## Advanced
+### Custom port
+
+It's possible to run PwnDoc on a custom port (for example `443`), not just the default port port `8433`. The following changes are needed to the `docker-compose.yml`:
+
+```yaml
+  pwndoc-frontend:
+    build:
+      context: ./frontend
+      args:
+       - API_PORT: 443 # <--
+    image: yeln4ts/pwndoc:frontend
+    container_name: pwndoc-frontend
+    restart: always
+    ports:
+      - 443:8443 # <--
+    networks:
+      - backend
+```
+
+Argument `API_PORT` is evaluated during frontend build time, therefore if you change it in `docker-compose.yml` than rebuild is necessary. If you want to build and start the containers, it's possible to use: `docker-compose up -d --build`
+

--- a/frontend/quasar.conf.js
+++ b/frontend/quasar.conf.js
@@ -37,13 +37,9 @@ module.exports = function (ctx) {
           '@': path.resolve(__dirname, '.', 'src')
         }
       },
-      env: ctx.dev
-        ? { // dev environnment
-          API_PORT: 5252
-        }
-        : { // prod environnment (build)
-          API_PORT: 8443,
-        }
+      env: {
+        API_PORT: process.env.API_PORT || (ctx.dev ? 5252 : 8443), // env, dev, prod
+      }
     },
     devServer: {
       https: {


### PR DESCRIPTION
Running PwnDoc on a custom port currently requires changes to files `docker-compose.yml` and `frontend/quasar.conf.js`. The second one is not documented, just referenced in the relevant issues (#176, #269).

I propose setting the port number directly in `docker-compose.yml` as a build argument. That way people don't have to manually edit other config files and have easier time upgrading to newer versions.

I've also added documentation for this feature. The changes are minimal and expression `API_PORT: process.env.API_PORT || (ctx.dev ? 5252 : 8443)` maintains backward compatibility (presuming environmental variable `API_PORT` was not used up until this point). If the environmental variable / build argument doesn't exist, it falls back to the original behavior.


