### PR TITLE
dark theme - nmap fix

### DIFF
--- a/frontend/src/pages/audits/edit/network/network.html
+++ b/frontend/src/pages/audits/edit/network/network.html
@@ -91,7 +91,6 @@
         :columns="dtHostHeaders"
         :pagination.sync="hostPagination"
         row-key="port"
-        style="background-color: white"
         />
     </div>
 </div>


### PR DESCRIPTION
Removed style making the nmap details unviewable in the dark theme