### PR TITLE
fixes #328 and adds visualStudio Directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ app-settings.json
 # Editor directories and files
 .idea
 .vscode
+.vs
 *.suo
 *.ntvs*
 *.njsproj

--- a/frontend/src/pages/audits/edit/network/network.html
+++ b/frontend/src/pages/audits/edit/network/network.html
@@ -5,7 +5,6 @@
         class="q-mr-sm"
         :label="$t('import')"
         no-caps
-        auto-close
         >
             <q-list>
                 <q-item clickable @click="$refs.nmapFile.click()">


### PR DESCRIPTION
The `auto-close` does something buggy in there. the `@change=` within the `<input type="file".....` will not be called, also the fileinput doesn't have a value after selecting a file.

It's fixed when clearing the `auto-close`.

