### PR TITLE
Fix Frontend start - Fix Node.js from LTS to v16

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 ### STAGE 1: Build ###
-FROM node:lts-alpine AS build
+FROM node:16-alpine AS build
 WORKDIR /app
 COPY package.json ./
 RUN npm install

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS build
+FROM node:16-alpine AS build
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
Hello, this PR fixes new builds of Frontend by switching their base Docker image from `node:lts-alpine` to `node:16-alpine` as explained in issue #383.
Long-term it would be better to fix the underlying issue, but that might be quite an undertaking. Node 16 is supported until [2023-09-11](https://github.com/nodejs/Release#release-schedule).

I've tried running the tests. Most of them fail, though I've found references in other issues that the tests are not be up-to-date. 

This PR changes base image only for Frontend. As far as I can tell, the Backend can be safely updated to the new Node LTS (v18). I have not found any compatibility issues running Frontend and Backend on two different Node versions.

Closes #383 