### PR TITLE
Fixed the validation regex to allow characters with marks (Ex. Latvian)

### DIFF
--- a/backend/src/lib/utils.js
+++ b/backend/src/lib/utils.js
@@ -1,6 +1,6 @@
 // Filename whitelist validation for template creation
 function validFilename(filename) {
-    const regex = /^[\u4e00-\u9fcfA-zÀ-ú0-9 \[\]\'()_-]+$/i;
+    const regex = /^[\p{Letter}\p{Mark}0-9 \[\]'()_-]+$/iu;
     
     return (regex.test(filename));
 }

--- a/backend/src/routes/data.js
+++ b/backend/src/routes/data.js
@@ -43,7 +43,7 @@ module.exports = function(app) {
             return;
         }
         if (!utils.validFilename(req.body.language) || !utils.validFilename(req.body.locale)) {
-            Response.BadParameters(res, 'language and locale value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+            Response.BadParameters(res, 'language and locale value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
             return
         }
         
@@ -74,7 +74,7 @@ module.exports = function(app) {
                 return
             }
             if (!utils.validFilename(language.language) || !utils.validFilename(language.locale)) {
-                Response.BadParameters(res, 'language and locale value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+                Response.BadParameters(res, 'language and locale value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
                 return
             }
         }
@@ -105,7 +105,7 @@ module.exports = function(app) {
             return;
         }
         if (!utils.validFilename(req.body.name)) {
-            Response.BadParameters(res, 'name and locale value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+            Response.BadParameters(res, 'name and locale value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
             return
         }
 
@@ -141,7 +141,7 @@ module.exports = function(app) {
                 return
             }
             if (!utils.validFilename(auditType.name)) {
-                Response.BadParameters(res, 'name and locale value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+                Response.BadParameters(res, 'name and locale value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
                 return
             }
         }
@@ -172,7 +172,7 @@ module.exports = function(app) {
             return;
         }
         if (!utils.validFilename(req.body.name) || !utils.validFilename(req.body.locale)) {
-            Response.BadParameters(res, 'name and locale value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+            Response.BadParameters(res, 'name and locale value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
             return
         }
 
@@ -202,7 +202,7 @@ module.exports = function(app) {
                 return
             }
             if (!utils.validFilename(vulnType.name) || !utils.validFilename(vulnType.locale)) {
-                Response.BadParameters(res, 'name and locale value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+                Response.BadParameters(res, 'name and locale value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
                 return
             }
         }
@@ -233,7 +233,7 @@ module.exports = function(app) {
             return;
         }
         if (!utils.validFilename(req.body.name)) {
-            Response.BadParameters(res, 'name value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+            Response.BadParameters(res, 'name value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
             return
         }
 
@@ -260,7 +260,7 @@ module.exports = function(app) {
                 return
             }
             if (!utils.validFilename(vulnCat.name)) {
-                Response.BadParameters(res, 'name value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+                Response.BadParameters(res, 'name value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
                 return
             }
         }
@@ -308,7 +308,7 @@ module.exports = function(app) {
             return;
         }
         if (!utils.validFilename(req.body.field) || !utils.validFilename(req.body.name)) {
-            Response.BadParameters(res, 'name and field value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i ')
+            Response.BadParameters(res, 'name and field value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
             return
         }
         
@@ -343,7 +343,7 @@ module.exports = function(app) {
                 return
             }
             if (!utils.validFilename(section.name) || !utils.validFilename(section.field)) {
-                Response.BadParameters(res, 'name and field value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+                Response.BadParameters(res, 'name and field value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
                 return
             }
         }
@@ -374,7 +374,7 @@ module.exports = function(app) {
             return
         }
         if ((!utils.validFilename(req.body.fieldType) || !utils.validFilename(req.body.label)) && req.body.fieldType !== 'space') {
-            Response.BadParameters(res, 'name and field value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i ')
+            Response.BadParameters(res, 'name and field value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
             return
         }
         
@@ -405,7 +405,7 @@ module.exports = function(app) {
                 return
             }
             if ((!utils.validFilename(customField.label || !utils.validFilename(customField.fieldType))) && customField.fieldType !== 'space') {
-                Response.BadParameters(res, 'label and fieldType value must match /^[A-zÀ-ú0-9 \[\]\'()_-]+$/i')
+                Response.BadParameters(res, 'label and fieldType value must match /^[\p{Letter}\p{Mark}0-9 \[\]\'()_-]+$/iu')
                 return
             }
         }

--- a/backend/tests/lib.test.js
+++ b/backend/tests/lib.test.js
@@ -17,6 +17,12 @@ module.exports = function () {
         expect(result).toEqual(true)
       })
 
+      it('Valid Latvian Filename', () => {
+        var filename = "Pažeidžiamumas 1"
+        var result = utils.validFilename(filename)
+        expect(result).toEqual(true)
+      })
+
       it('Valid Filename with special chars', () => {
         var filename = "Vulnerability_1-test"
         var result = utils.validFilename(filename)

--- a/docs/data.md
+++ b/docs/data.md
@@ -72,7 +72,7 @@ A Template is defined by:
 
 Custom Data represent a way to fully customize Audits and Vulnerabilities. They are editable and their order can be changed to personalize how they will be displayed for users.
 
-!> Values must match this regex:  `/^[A-zÀ-ú0-9 \[\]\'()_-]+$/`
+!> Values must match this regex:  `/^[\p{Letter}\p{Mark}0-9 \[\]'()_-]+$/iu`
 
 ### Languages
 


### PR DESCRIPTION
Fix for issue #371 

This replaces the [A-Z] check with the proper Unicode version to allow for Unicode letters while still preventing control / dangerous characters