### PR TITLE
Automatically build docker releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,114 @@
+name: Build & publish pwndoc images
+on:
+  push:
+    branches: [ "main", "docker-publish" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE.md'
+      - 'README.md'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./backend/Dockerfile
+            image: ghcr.io/${{ github.repository }}
+            tag: backend
+          - dockerfile: ./frontend/Dockerfile
+            image: ghcr.io/${{ github.repository }}
+            tag: frontend
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.13.1'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ matrix.image }}
+          # Disable latest cause we have multiple images
+          flavor: |
+            latest=false
+            prefix=${{ matrix.tag }}-
+          tags: |
+            type=sha,prefix=${{ matrix.tag }}-
+            type=raw,value=latest
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: ${{ matrix.tag }}
+          push: true
+          file: ${{ matrix.dockerfile }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=PwnDoc ${{ matrix.tag }} image
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: |-
+              linux/amd64
+              linux/arm64
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       - backend
 
   pwndoc-backend:
-    build: ./backend
-    image: yeln4ts/pwndoc:backend
+    image: ghcr.io/pwndoc/pwndoc:backend-latest
     container_name: pwndoc-backend
     volumes:
       - ./backend/report-templates:/app/report-templates
@@ -27,12 +26,11 @@ services:
       - 4242:4242
     links:
       - mongodb
-    networks: 
+    networks:
       - backend
 
   pwndoc-frontend:
-    build: ./frontend
-    image: yeln4ts/pwndoc:frontend
+    image: ghcr.io/pwndoc/pwndoc:frontend-latest
     container_name: pwndoc-frontend
     restart: always
     ports:


### PR DESCRIPTION
This PR implements #456 by enabling a new Github Action that will periodically build PwnDoc docker images for every push to the `main` branch or for every new release version tag.

By doing so we can ease the update (and installation) process of PwnDoc since users will download the pre-build image  from Github Container Registry instead of building the containers on their own.

----

The main [docker-container.yml](https://github.com/TheZ3ro/pwndoc/blob/cc61827be08dacf10b371310e9e72a03f58643b1/docker-compose.yml) will now point to `ghcr.io/pwndoc/pwndoc` and won't build on users' host anymore.

The [.github/workflows/docker-publish.yml](https://github.com/TheZ3ro/pwndoc/blob/cc61827be08dacf10b371310e9e72a03f58643b1/.github/workflows/docker-publish.yml) will build the 2 PwnDoc containers: frontend & backend.

Every build is compiled both for `linux/amd64` or `linux/arm64`.

Every build has `tags` that points to the various versions:
- `frontend-latest` / `backend-latest` will point to the latest commit in `main` branch build.
  e.g. `ghcr.io/pwndoc/pwndoc:frontend-latest`
- `frontend-x.x.x` / `backend-x.x.x` will point to the specific release/git tag build.
  e.g. `ghcr.io/pwndoc/pwndoc:frontend-0.5.9`
- `frontend-xxxxxxx` / `backend-xxxxxxx` will point to a specific commit build.
  e.g. `ghcr.io/pwndoc/pwndoc:frontend-c24fba9`

----- 

You can see a demo of everything here:
- [Github Actions](https://github.com/TheZ3ro/pwndoc/actions/workflows/docker-publish.yml)
- [Github Container Registry Package](https://github.com/thez3ro/pwndoc/pkgs/container/pwndoc)

