### PR TITLE
Added feature websocket port

### DIFF
--- a/frontend/src/boot/socketio.js
+++ b/frontend/src/boot/socketio.js
@@ -3,7 +3,14 @@ import {Loading} from 'quasar'
 import { $t } from '@/boot/i18n'
 
 export default ({ Vue }) => {
-    var socket = io(`${window.location.protocol}//${window.location.hostname}:${process.env.API_PORT}`);
+    var socketUrl = `${window.location.protocol}//${window.location.hostname}`;
+    if (process.env.API_PORT) {
+       socketUrl = socketUrl + ":" + process.env.API_PORT;
+    } else if (window.location.port) {
+       socketUrl = socketUrl + ":" + window.location.port;
+    }
+
+    var socket = io(socketUrl);
 
     socket.on('disconnect', (error) => {
         Loading.show({


### PR DESCRIPTION
For the frontend, if the `API_PORT` is falsy, the websocket it will instead use the same port as the frontend using the `window.location.port` property.