### PR TITLE
count by "vulnType" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # PwnDoc
-This Branch has "counttype" function.
-
 PwnDoc is a pentest reporting application making it simple and easy to write your findings and generate a customizable Docx report.  
 The main goal is to have more time to **Pwn** and less time to **Doc** by mutualizing data like vulnerabilities between users.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PwnDoc
+This Branch has "counttype" function.
 
 PwnDoc is a pentest reporting application making it simple and easy to write your findings and generate a customizable Docx report.  
 The main goal is to have more time to **Pwn** and less time to **Doc** by mutualizing data like vulnerabilities between users.

--- a/backend/src/lib/report-filters.js
+++ b/backend/src/lib/report-filters.js
@@ -334,6 +334,22 @@ expressions.filters.count = function(input, severity) {
     return count;
 }
 
+// Count by vulnType 
+// Example: {findings | counttype: 'Info'}
+// This is good for custom vulnType, instead using "count" which is using only cvss severity. in base case when cvss is 0.0 = Informational , you wont be able to count the informative findings.
+expressions.filters.counttype = function(input, vulnType) {
+    if (!input) return input;
+    var count = 0;
+
+    for (var i = 0; i < input.length; i++) {
+        if (input[i].VulnType === vulnType) {
+            count += 1;
+        }
+    }
+
+    return count;
+}
+
 // Translate using locale from 'translate' folder
 // Example: {input | translate: 'fr'}
 expressions.filters.translate = function(input, locale) {


### PR DESCRIPTION
I was struggling to count " Informational " vulnerabilities due to it is a custom field and it is not included in the cvss calculator. 
This is good for custom vulnType, instead using "count" which is using only cvss severity. in base case when cvss is 0.0 = Informational , you wont be able to count the informative findings.
![image](https://github.com/pwndoc/pwndoc/assets/93482738/fd479aa7-b0fd-4d3f-a7ee-b9fb40cb0cc5)

This contribute allows the user to count also custom fields.  