### PR TITLE
Update Node.js Base Image to v17 in frontend Dockerfile for Compatibility Fixes

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 ### STAGE 1: Build ###
-FROM node:lts-alpine AS build
+FROM node:17-alpine AS build
 WORKDIR /app
 COPY package.json ./
 RUN npm install


### PR DESCRIPTION
I've updated the Node.js base image in our Dockerfile from node:lts-alpine to node:17-alpine. This switch resolves the build failures and compatibility issues we were facing with the dependencies on the previous LTS version.