### PR TITLE
fix: use volume for SSL certs (dynamic updates)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
   pwndoc-frontend:
     image: ghcr.io/pwndoc/pwndoc-frontend:latest
     container_name: pwndoc-frontend
+    volumes:
+      - ./frontend/ssl:/etc/nginx/ssl:ro
     restart: always
     ports:
       - ${APP_PORT}:8443

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,5 @@ RUN npm run build
 ### STAGE 2: Run ###
 FROM nginx:stable-alpine
 COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
-RUN mkdir -p /etc/nginx/ssl
-COPY ssl/server* /etc/nginx/ssl/
 COPY --from=build /app/dist/spa /usr/share/nginx/html
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
The current Dockerfile instructions in frontend image aren't able to properly copy the SSL certificates when they are changed. This is due to docker not identifying a modification to monitored files, which is expected. 

To correct this behavior, I created a ro volume mapping the nginx ssl folder to the frontend/ssl folder, which is loaded at every start of the frontend container  and allow the change of certificate as expected in production