### PR TITLE
feat: handle MONGODB_URI env var as connection string

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -24,6 +24,8 @@ var io = require('socket.io')(https, {
 var bodyParser = require('body-parser');
 var cookieParser = require('cookie-parser')
 var utils = require('./lib/utils');
+const config = require('./config/config.json');
+const env = process.env.NODE_ENV || 'dev';
 
 // Get configuration
 global.__basedir = __dirname;
@@ -35,10 +37,15 @@ mongoose.Promise = global.Promise;
 // Trim all Strings
 mongoose.Schema.Types.String.set('trim', true);
 
+let connectionOptions = {};
+if (config && config[env] && config[env].database && config[env].database.connectionOptions) {
+  connectionOptions = config[env].database.connectionOptions;
+}
+
 if (process.env.MONGODB_URI) {
-  mongoose.connect(process.env.MONGODB_URI, {});
+  mongoose.connect(process.env.MONGODB_URI, connectionOptions);
 } else {
-  mongoose.connect(`mongodb://${process.env.DB_SERVER}:27017/${process.env.DB_NAME}`, {});
+  mongoose.connect(`mongodb://${process.env.DB_SERVER}:27017/${process.env.DB_NAME}`, connectionOptions);
 }
 
 // Models import

--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -1,10 +1,17 @@
 const request = require("supertest");
+const config = require("../src/config/config.json");
+const env = process.env.NODE_ENV || 'dev';
 
 var mongoose = require('mongoose');
+
+let connectionOptions = {};
+if (config && config[env] && config[env].database && config[env].database.connectionOptions) {
+  connectionOptions = config[env].database.connectionOptions;
+}
 if (process.env.MONGODB_URI) {
-  mongoose.connect(process.env.MONGODB_URI, {});
+  mongoose.connect(process.env.MONGODB_URI, connectionOptions);
 } else {
-  mongoose.connect(`mongodb://${process.env.DB_SERVER}:27017/${process.env.DB_NAME}`, {});
+  mongoose.connect(`mongodb://${process.env.DB_SERVER}:27017/${process.env.DB_NAME}`, connectionOptions);
 }
 
 /* Clean the DB */


### PR DESCRIPTION
As described in #604:

Add support for `MONGODB_URI` env var that, when present, fully overrides the connection string passed to `mongoose.connect`. If it’s not set, keep the current behavior for backward compatibility.

1. If `process.env.MONGODB_URI` is defined, use it verbatim.
2. Otherwise, fall back to the existing `mongodb://${DB_SERVER}:27017/${DB_NAME}`.

