### PR TITLE
 AI-assisted report generation

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -60,6 +60,7 @@ require('./models/vulnerability-type');
 require('./models/vulnerability-category');
 require('./models/custom-section');
 require('./models/custom-field');
+require('./models/ai-prompt');
 require('./models/image');
 require('./models/settings');
 require('./models/dictionary');

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -150,6 +150,7 @@ require('./routes/backup')(app);
 require('./routes/test-utils')(app);
 require('./routes/spellcheck')(app);
 require('./routes/languagetool-rules')(app);
+require('./routes/ai')(app);
 
 app.all(/(.*)/, function(req, res) {
     res.status(404).json({"status": "error", "data": "Route undefined"});

--- a/backend/src/lib/ai-prompts.js
+++ b/backend/src/lib/ai-prompts.js
@@ -1,8 +1,76 @@
-const DEFAULT_AI_PROMPTS = {
-    description: 'Write a technical finding description for "{title}" in the "{vulnType}" category. Explain what is vulnerable and the business/security impact.',
-    observation: 'Write a clear observation for "{title}" using available evidence. Include exploitation path and realistic attacker impact.',
-    remediation: 'Write practical remediation for "{title}" with prioritized, concrete actions and verification guidance.',
-    references: 'Provide concise references for "{title}" in "{vulnType}". Include standards or authoritative guidance when possible.'
+const AI_PROVIDERS = ['openai', 'anthropic', 'deepseek', 'ollama'];
+const AI_DEFAULT_PROVIDER = 'openai';
+
+const AI_PROVIDER_DEFAULTS = {
+    openai: {
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4.1-mini',
+        timeoutMs: 30000
+    },
+    anthropic: {
+        baseUrl: 'https://api.anthropic.com/v1',
+        model: 'claude-3-5-sonnet-latest',
+        timeoutMs: 30000,
+        version: '2023-06-01'
+    },
+    deepseek: {
+        baseUrl: 'https://api.deepseek.com/v1',
+        model: 'deepseek-chat',
+        timeoutMs: 30000
+    },
+    ollama: {
+        baseUrl: 'http://localhost:11434/v1',
+        model: 'llama3.1',
+        timeoutMs: 60000
+    }
+};
+
+const BUILTIN_FINDING_FIELDS = [
+    {
+        entityType: 'finding',
+        fieldKey: 'description',
+        fieldLabel: 'Description',
+        outputType: 'html',
+        defaultPrompt: 'Write a technical finding description for "{title}" in the "{vulnType}" category. Explain what is vulnerable and the business/security impact.'
+    },
+    {
+        entityType: 'finding',
+        fieldKey: 'observation',
+        fieldLabel: 'Observation',
+        outputType: 'html',
+        defaultPrompt: 'Write a clear observation for "{title}" using available evidence. Include exploitation path and realistic attacker impact.'
+    },
+    {
+        entityType: 'finding',
+        fieldKey: 'remediation',
+        fieldLabel: 'Remediation',
+        outputType: 'html',
+        defaultPrompt: 'Write practical remediation for "{title}" with prioritized, concrete actions and verification guidance.'
+    },
+    {
+        entityType: 'finding',
+        fieldKey: 'references',
+        fieldLabel: 'References',
+        outputType: 'array',
+        defaultPrompt: 'Provide concise references for "{title}" in "{vulnType}". Include standards or authoritative guidance when possible.'
+    },
+    {
+        entityType: 'finding',
+        fieldKey: 'poc',
+        fieldLabel: 'Proofs',
+        outputType: 'html',
+        defaultPrompt: 'Write a concise proof-of-concept section for "{title}" with reproducible steps and expected/observed behavior.'
+    }
+];
+
+const CUSTOM_FIELD_OUTPUT_TYPES = {
+    text: 'html',
+    input: 'text',
+    date: 'text',
+    select: 'text',
+    radio: 'text',
+    'select-multiple': 'array',
+    checkbox: 'array'
 };
 
 const normalizePromptValue = (value) => {
@@ -11,22 +79,105 @@ const normalizePromptValue = (value) => {
     return String(value).trim();
 }
 
-const mergeWithDefaults = (prompts = {}) => {
-    const result = {};
-    Object.keys(DEFAULT_AI_PROMPTS).forEach((field) => {
-        const candidate = normalizePromptValue(prompts[field]);
-        result[field] = candidate || DEFAULT_AI_PROMPTS[field];
-    });
-    return result;
+const toCustomFieldKey = (customFieldId) => `custom-field:${customFieldId}`;
+
+const toPromptCompositeKey = (entityType, fieldKey) => `${entityType}::${fieldKey}`;
+
+const getDefaultPromptForField = (fieldLabel, outputType) => {
+    if (outputType === 'array') {
+        return `Generate concise entries for "${fieldLabel}" from the provided context. Return practical, non-duplicated items.`;
+    }
+
+    if (outputType === 'html') {
+        return `Write content for "${fieldLabel}" using HTML paragraphs (<p>...</p>) based on the provided context.`;
+    }
+
+    return `Write concise text for "${fieldLabel}" based on the provided context.`;
 }
 
-const getAiPromptsFromSettings = (settings = {}) => {
-    const prompts = settings?.ai?.public?.prompts || {};
-    return mergeWithDefaults(prompts);
+const buildCustomFieldCatalog = (customFields = [], entityType, displayFilter, labelPrefix) => {
+    return (customFields || [])
+    .filter((field) => displayFilter.includes(String(field?.display || '')))
+    .map((field) => {
+        const outputType = CUSTOM_FIELD_OUTPUT_TYPES[field?.fieldType];
+        if (!outputType)
+            return null;
+
+        return {
+            entityType: entityType,
+            fieldKey: toCustomFieldKey(field._id),
+            fieldLabel: `${labelPrefix}: ${field.label}`,
+            outputType: outputType,
+            defaultPrompt: getDefaultPromptForField(field.label, outputType),
+            source: 'custom-field',
+            customFieldId: String(field._id),
+            customFieldType: String(field.fieldType || '')
+        };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.fieldLabel.localeCompare(b.fieldLabel));
+}
+
+const buildFindingFieldCatalog = (customFields = []) => {
+    return [
+        ...BUILTIN_FINDING_FIELDS.map((field) => ({
+            ...field,
+            source: 'builtin',
+            customFieldId: null,
+            customFieldType: null
+        })),
+        ...buildCustomFieldCatalog(customFields, 'finding', ['finding', 'vulnerability'], 'Finding Custom Field')
+    ];
+}
+
+const buildSectionFieldCatalog = (customFields = []) => {
+    return buildCustomFieldCatalog(customFields, 'section', ['section'], 'Section Custom Field');
+}
+
+const buildAiFieldCatalog = (customFields = []) => {
+    return [
+        ...buildFindingFieldCatalog(customFields),
+        ...buildSectionFieldCatalog(customFields)
+    ];
+}
+
+const buildPromptMappings = (fieldCatalog = [], promptRows = []) => {
+    const promptByCompositeKey = new Map(
+        (promptRows || []).map((row) => {
+            const entityType = String(row.entityType || '').trim();
+            const fieldKey = String(row.fieldKey || '').trim();
+            return [toPromptCompositeKey(entityType, fieldKey), row];
+        })
+    );
+
+    return fieldCatalog.map((field) => {
+        const promptRow = promptByCompositeKey.get(toPromptCompositeKey(field.entityType, field.fieldKey));
+        const configuredPrompt = normalizePromptValue(promptRow?.prompt);
+        return {
+            entityType: field.entityType,
+            fieldKey: field.fieldKey,
+            fieldLabel: field.fieldLabel,
+            outputType: field.outputType,
+            source: field.source,
+            customFieldId: field.customFieldId,
+            customFieldType: field.customFieldType,
+            enabled: typeof promptRow?.enabled === 'boolean' ? promptRow.enabled : true,
+            prompt: configuredPrompt || field.defaultPrompt
+        };
+    });
 }
 
 module.exports = {
-    DEFAULT_AI_PROMPTS,
-    mergeWithDefaults,
-    getAiPromptsFromSettings
+    AI_PROVIDERS,
+    AI_DEFAULT_PROVIDER,
+    AI_PROVIDER_DEFAULTS,
+    BUILTIN_FINDING_FIELDS,
+    CUSTOM_FIELD_OUTPUT_TYPES,
+    normalizePromptValue,
+    toCustomFieldKey,
+    toPromptCompositeKey,
+    buildFindingFieldCatalog,
+    buildSectionFieldCatalog,
+    buildAiFieldCatalog,
+    buildPromptMappings
 };

--- a/backend/src/lib/ai-prompts.js
+++ b/backend/src/lib/ai-prompts.js
@@ -1,0 +1,32 @@
+const DEFAULT_AI_PROMPTS = {
+    description: 'Write a technical finding description for "{title}" in the "{vulnType}" category. Explain what is vulnerable and the business/security impact.',
+    observation: 'Write a clear observation for "{title}" using available evidence. Include exploitation path and realistic attacker impact.',
+    remediation: 'Write practical remediation for "{title}" with prioritized, concrete actions and verification guidance.',
+    references: 'Provide concise references for "{title}" in "{vulnType}". Include standards or authoritative guidance when possible.'
+};
+
+const normalizePromptValue = (value) => {
+    if (value === null || value === undefined)
+        return '';
+    return String(value).trim();
+}
+
+const mergeWithDefaults = (prompts = {}) => {
+    const result = {};
+    Object.keys(DEFAULT_AI_PROMPTS).forEach((field) => {
+        const candidate = normalizePromptValue(prompts[field]);
+        result[field] = candidate || DEFAULT_AI_PROMPTS[field];
+    });
+    return result;
+}
+
+const getAiPromptsFromSettings = (settings = {}) => {
+    const prompts = settings?.ai?.public?.prompts || {};
+    return mergeWithDefaults(prompts);
+}
+
+module.exports = {
+    DEFAULT_AI_PROMPTS,
+    mergeWithDefaults,
+    getAiPromptsFromSettings
+};

--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -76,7 +76,9 @@ var builtInRoles = {
             'settings:read-public',
             // Spellcheck
             'spellcheck:read',
-            'spellcheck:create'
+            'spellcheck:create',
+            // AI
+            'ai:generate'
         ]
     },
     admin: {

--- a/backend/src/lib/html2ooxml.js
+++ b/backend/src/lib/html2ooxml.js
@@ -92,7 +92,11 @@ function html2ooxml(html, style = '') {
                     cParagraphProperties.bullet = {level: 0}
             }
             else if (tag === "code") {
-                cRunProperties.style = "CodeChar"
+                // Only apply the CodeChar character style to standalone inline
+                // <code>. Nested <code> inside <pre> keeps just the Code
+                // paragraph style so it doesn't override the code block styling.
+                if (!inCodeBlock)
+                    cRunProperties.style = "CodeChar"
             }
             else if (tag === "legend" && attribs && attribs.alt !== "undefined") {
                 var label = attribs.label || "Figure"
@@ -161,7 +165,8 @@ function html2ooxml(html, style = '') {
                     cParagraphProperties = {}
             }
             else if (tag === "code") {
-                delete cRunProperties.style
+                if (!inCodeBlock)
+                    delete cRunProperties.style
             } else if (tag === "span" && inCodeBlock) {
                 delete cRunProperties.color
                 delete cRunProperties.italics

--- a/backend/src/models/ai-prompt.js
+++ b/backend/src/models/ai-prompt.js
@@ -1,0 +1,120 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var AiPromptSchema = new Schema({
+    entityType: {type: String, required: true, default: 'finding', enum: ['finding', 'section']},
+    fieldKey: {type: String, required: true},
+    fieldLabel: {type: String, required: true},
+    outputType: {type: String, required: true, enum: ['html', 'text', 'array']},
+    enabled: {type: Boolean, default: true},
+    prompt: {type: String, default: ''},
+    customFieldId: {type: Schema.Types.ObjectId, required: false, default: null}
+}, {timestamps: true, strict: true});
+
+AiPromptSchema.index({entityType: 1, fieldKey: 1}, {
+    name: 'unique_entity_field_key',
+    unique: true
+});
+
+AiPromptSchema.statics.backup = (path) => {
+    return new Promise(async (resolve, reject) => {
+        const fs = require('fs');
+
+        function exportAiPromptsPromise() {
+            return new Promise((resolve, reject) => {
+                const writeStream = fs.createWriteStream(`${path}/aiPrompts.json`);
+                writeStream.write('[');
+
+                let prompts = AiPrompt.find().cursor();
+                let isFirst = true;
+
+                prompts.eachAsync(async (document) => {
+                    if (!isFirst) {
+                        writeStream.write(',');
+                    } else {
+                        isFirst = false;
+                    }
+                    writeStream.write(JSON.stringify(document, null, 2));
+                    return Promise.resolve();
+                })
+                .then(() => {
+                    writeStream.write(']');
+                    writeStream.end();
+                })
+                .catch((error) => {
+                    reject(error);
+                });
+
+                writeStream.on('finish', () => {
+                    resolve('ok');
+                });
+
+                writeStream.on('error', (error) => {
+                    reject(error);
+                });
+            });
+        }
+
+        try {
+            await exportAiPromptsPromise();
+            resolve();
+        }
+        catch (error) {
+            reject({error: error, model: 'AiPrompt'});
+        }
+    });
+}
+
+AiPromptSchema.statics.restore = (path, mode = 'upsert') => {
+    return new Promise(async (resolve, reject) => {
+        const fs = require('fs');
+
+        function importAiPromptsPromise() {
+            return new Promise((resolve, reject) => {
+                const readStream = fs.createReadStream(`${path}/aiPrompts.json`);
+                const JSONStream = require('JSONStream');
+
+                let jsonStream = JSONStream.parse('*');
+                readStream.pipe(jsonStream);
+
+                readStream.on('error', (error) => {
+                    if (error.code === 'ENOENT') {
+                        resolve();
+                        return;
+                    }
+                    reject(error);
+                });
+
+                jsonStream.on('data', async (document) => {
+                    AiPrompt.findOneAndReplace(
+                        {entityType: document.entityType, fieldKey: document.fieldKey},
+                        document,
+                        {upsert: true}
+                    )
+                    .catch((err) => {
+                        console.log(err);
+                        reject(err);
+                    });
+                });
+                jsonStream.on('end', () => {
+                    resolve();
+                });
+                jsonStream.on('error', (error) => {
+                    reject(error);
+                });
+            });
+        }
+
+        try {
+            if (mode === 'revert')
+                await AiPrompt.deleteMany();
+            await importAiPromptsPromise();
+            resolve();
+        }
+        catch (error) {
+            reject({error: error, model: 'AiPrompt'});
+        }
+    });
+}
+
+var AiPrompt = mongoose.model('AiPrompt', AiPromptSchema);

--- a/backend/src/models/settings.js
+++ b/backend/src/models/settings.js
@@ -2,7 +2,7 @@ var mongoose = require('mongoose');//.set('debug', true);
 var Schema = mongoose.Schema;
 var _ = require('lodash');
 var Utils = require('../lib/utils.js');
-const { DEFAULT_AI_PROMPTS } = require('../lib/ai-prompts');
+const { AI_PROVIDERS, AI_DEFAULT_PROVIDER } = require('../lib/ai-prompts');
 
 // https://stackoverflow.com/questions/25822289/what-is-the-best-way-to-store-color-hex-values-in-mongodb-mongoose
 const colorValidator = (v) => (/^#([0-9a-f]{3}){1,2}$/i).test(v);
@@ -64,18 +64,20 @@ const SettingSchema = new Schema({
     },
     ai: {
         public: {
-            defaultProvider: {type: String, enum: ['mock', 'openai', 'anthropic', 'deepseek', 'ollama'], default: 'mock'},
-            prompts: {
-                description: {type: String, default: DEFAULT_AI_PROMPTS.description},
-                observation: {type: String, default: DEFAULT_AI_PROMPTS.observation},
-                remediation: {type: String, default: DEFAULT_AI_PROMPTS.remediation},
-                references: {type: String, default: DEFAULT_AI_PROMPTS.references}
-            }
+            enabled: {type: Boolean, default: true},
+            defaultProvider: {type: String, enum: AI_PROVIDERS, default: AI_DEFAULT_PROVIDER}
         },
         private: {
             openaiApiKey: {type: String, default: ''},
+            openaiBaseUrl: {type: String, default: 'https://api.openai.com/v1'},
+            openaiModel: {type: String, default: 'gpt-4.1-mini'},
             anthropicApiKey: {type: String, default: ''},
+            anthropicBaseUrl: {type: String, default: 'https://api.anthropic.com/v1'},
+            anthropicModel: {type: String, default: 'claude-3-5-sonnet-latest'},
+            anthropicVersion: {type: String, default: '2023-06-01'},
             deepseekApiKey: {type: String, default: ''},
+            deepseekBaseUrl: {type: String, default: 'https://api.deepseek.com/v1'},
+            deepseekModel: {type: String, default: 'deepseek-chat'},
             ollamaApiKey: {type: String, default: ''},
             ollamaBaseUrl: {type: String, default: 'http://localhost:11434/v1'},
             ollamaModel: {type: String, default: 'llama3.1'}
@@ -100,7 +102,7 @@ SettingSchema.statics.getAll = () => {
 SettingSchema.statics.getPublic = () => {
     return new Promise((resolve, reject) => {
         const query = Settings.findOne({});
-        query.select('-_id report.enabled report.public reviews.enabled reviews.public');
+        query.select('-_id report.enabled report.public reviews.enabled reviews.public ai.public');
         query.exec()
             .then(settings => resolve(settings))
             .catch(err => reject(err));
@@ -247,6 +249,15 @@ Settings.findOne()
             _.set(liveSettings, path, undefined)
         }
     })
+
+    if (!AI_PROVIDERS.includes(liveSettings?.ai?.public?.defaultProvider)) {
+        needUpdate = true
+        _.set(liveSettings, 'ai.public.defaultProvider', AI_DEFAULT_PROVIDER)
+    }
+    if (typeof liveSettings?.ai?.public?.enabled !== 'boolean') {
+        needUpdate = true
+        _.set(liveSettings, 'ai.public.enabled', true)
+    }
 
     if (needUpdate) {
         console.log("Removing unused fields from Settings")

--- a/backend/src/models/settings.js
+++ b/backend/src/models/settings.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');//.set('debug', true);
 var Schema = mongoose.Schema;
 var _ = require('lodash');
 var Utils = require('../lib/utils.js');
+const { DEFAULT_AI_PROMPTS } = require('../lib/ai-prompts');
 
 // https://stackoverflow.com/questions/25822289/what-is-the-best-way-to-store-color-hex-values-in-mongodb-mongoose
 const colorValidator = (v) => (/^#([0-9a-f]{3}){1,2}$/i).test(v);
@@ -59,6 +60,25 @@ const SettingSchema = new Schema({
         },
         private: {
             removeApprovalsUponUpdate: { type: Boolean, default: false }
+        }
+    },
+    ai: {
+        public: {
+            defaultProvider: {type: String, enum: ['mock', 'openai', 'anthropic', 'deepseek', 'ollama'], default: 'mock'},
+            prompts: {
+                description: {type: String, default: DEFAULT_AI_PROMPTS.description},
+                observation: {type: String, default: DEFAULT_AI_PROMPTS.observation},
+                remediation: {type: String, default: DEFAULT_AI_PROMPTS.remediation},
+                references: {type: String, default: DEFAULT_AI_PROMPTS.references}
+            }
+        },
+        private: {
+            openaiApiKey: {type: String, default: ''},
+            anthropicApiKey: {type: String, default: ''},
+            deepseekApiKey: {type: String, default: ''},
+            ollamaApiKey: {type: String, default: ''},
+            ollamaBaseUrl: {type: String, default: 'http://localhost:11434/v1'},
+            ollamaModel: {type: String, default: 'llama3.1'}
         }
     }
 }, {strict: true});

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -1,7 +1,16 @@
 const Response = require('../lib/httpResponse.js');
 const acl = require('../lib/auth').acl;
 const Settings = require('mongoose').model('Settings');
-const { getAiPromptsFromSettings } = require('../lib/ai-prompts');
+const CustomField = require('mongoose').model('CustomField');
+const AiPrompt = require('mongoose').model('AiPrompt');
+const {
+    AI_PROVIDERS,
+    AI_DEFAULT_PROVIDER,
+    AI_PROVIDER_DEFAULTS,
+    normalizePromptValue,
+    toPromptCompositeKey,
+    buildAiFieldCatalog
+} = require('../lib/ai-prompts');
 
 const toBaseUrl = (value, fallback) => String(value || fallback).replace(/\/+$/g, '');
 const toTimeout = (value, fallback) => {
@@ -9,40 +18,13 @@ const toTimeout = (value, fallback) => {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-const OPENAI_BASE_URL = toBaseUrl(process.env.AI_OPENAI_BASE_URL, 'https://api.openai.com/v1');
-const OPENAI_MODEL = process.env.AI_OPENAI_MODEL || 'gpt-4.1-mini';
-const OPENAI_TIMEOUT_MS = toTimeout(process.env.AI_OPENAI_TIMEOUT_MS, 30000);
-
-const DEEPSEEK_BASE_URL = toBaseUrl(process.env.AI_DEEPSEEK_BASE_URL, 'https://api.deepseek.com/v1');
-const DEEPSEEK_MODEL = process.env.AI_DEEPSEEK_MODEL || 'deepseek-chat';
-const DEEPSEEK_TIMEOUT_MS = toTimeout(process.env.AI_DEEPSEEK_TIMEOUT_MS, 30000);
-
-const OLLAMA_BASE_URL = toBaseUrl(process.env.AI_OLLAMA_BASE_URL, 'http://localhost:11434/v1');
-const OLLAMA_MODEL = process.env.AI_OLLAMA_MODEL || 'llama3.1';
-const OLLAMA_TIMEOUT_MS = toTimeout(process.env.AI_OLLAMA_TIMEOUT_MS, 60000);
-
-const ANTHROPIC_BASE_URL = toBaseUrl(process.env.AI_ANTHROPIC_BASE_URL, 'https://api.anthropic.com/v1');
-const ANTHROPIC_MODEL = process.env.AI_ANTHROPIC_MODEL || 'claude-3-5-sonnet-latest';
-const ANTHROPIC_TIMEOUT_MS = toTimeout(process.env.AI_ANTHROPIC_TIMEOUT_MS, 30000);
-const ANTHROPIC_VERSION = process.env.AI_ANTHROPIC_VERSION || '2023-06-01';
-
-const SUPPORTED_FIELDS = ['description', 'observation', 'remediation', 'references'];
-const SUPPORTED_PROVIDERS = ['mock', 'openai', 'anthropic', 'deepseek', 'ollama'];
-
-const escapeHtml = (value = '') => {
-    return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 const normalizeContextValue = (value) => {
     if (value === null || value === undefined)
         return '';
     if (Array.isArray(value))
         return value.join(', ');
+    if (typeof value === 'object')
+        return JSON.stringify(value);
     return String(value);
 }
 
@@ -64,47 +46,6 @@ const toReferenceArray = (value) => {
         .filter(Boolean);
     }
     return [];
-}
-
-const uniqStrings = (values = []) => {
-    return [...new Set(values.map((value) => String(value).trim()).filter(Boolean))];
-}
-
-const buildMockDraft = (field, context = {}, promptInstruction = '', userPrompt = '') => {
-    const title = escapeHtml(context.title || 'the identified issue');
-    const vulnType = escapeHtml(context.vulnType || 'security');
-    const observation = escapeHtml(context.observation || '');
-    const description = escapeHtml(context.description || '');
-    const remediation = escapeHtml(context.remediation || '');
-    const prompt = escapeHtml(userPrompt || promptInstruction || '');
-
-    if (field === 'references') {
-        const output = [];
-        if (prompt)
-            output.push(prompt);
-        output.push(`OWASP Testing Guide - ${title}`);
-        if (vulnType)
-            output.push(`${vulnType} Security Verification Reference`);
-        return uniqStrings([...output, ...toReferenceArray(context.references)]).slice(0, 5);
-    }
-
-    const firstParagraph = prompt || `Draft for ${field} related to ${title}.`;
-    let secondParagraph = '';
-    if (field === 'description') {
-        secondParagraph = observation ?
-            `Observed behavior: ${observation}` :
-            'Further technical validation should document attack prerequisites and impact boundaries.';
-    } else if (field === 'observation') {
-        secondParagraph = description ?
-            `Context from description: ${description}` :
-            'Capture reproducible steps, affected components, and attacker-controlled conditions.';
-    } else if (field === 'remediation') {
-        secondParagraph = remediation ?
-            `Existing remediation notes: ${remediation}` :
-            'Prioritize practical controls, ownership, and verification steps to reduce risk.';
-    }
-
-    return `<p>${firstParagraph}</p><p>${secondParagraph}</p>`;
 }
 
 const normalizeProvider = (provider) => {
@@ -139,25 +80,27 @@ const extractJsonObjectFromText = (text = '') => {
     }
 }
 
-const getDraftFromParsed = (field, parsed = {}, providerLabel = 'AI provider') => {
-    if (field === 'references') {
-        const refs = toReferenceArray(parsed.references || parsed[field]);
+const getDraftFromParsed = (outputType, parsed = {}, providerLabel = 'AI provider') => {
+    const raw = parsed?.draft;
+
+    if (outputType === 'array') {
+        const refs = toReferenceArray(raw);
         if (refs.length === 0) {
             throw({
                 fn: 'BadRequest',
-                message: `${providerLabel} response is missing valid references`
+                message: `${providerLabel} response is missing a valid array draft`
             });
         }
         return refs;
     }
 
-    const raw = parsed[field];
     if (typeof raw !== 'string' || !raw.trim()) {
         throw({
             fn: 'BadRequest',
-            message: `${providerLabel} response is missing a valid "${field}" value`
+            message: `${providerLabel} response is missing a valid text draft`
         });
     }
+
     return raw.trim();
 }
 
@@ -173,9 +116,30 @@ const normalizeOpenAIContent = (content) => {
     return '';
 }
 
+const getSystemPrompt = (outputType) => {
+    if (outputType === 'array') {
+        return [
+            'You are an assistant writing pentest report content.',
+            'Return ONLY valid JSON with one key: "draft" as an array of concise strings.'
+        ].join(' ');
+    }
+
+    if (outputType === 'text') {
+        return [
+            'You are an assistant writing pentest report content.',
+            'Return ONLY valid JSON with one key: "draft" as plain text without markdown fences.'
+        ].join(' ');
+    }
+
+    return [
+        'You are an assistant writing pentest report content.',
+        'Return ONLY valid JSON with one key: "draft" as HTML paragraphs using <p>...</p> without markdown fences.'
+    ].join(' ');
+}
+
 const generateWithOpenAICompatible = async ({
     providerLabel,
-    field,
+    outputType,
     context = {},
     promptInstruction = '',
     userPrompt = '',
@@ -194,15 +158,9 @@ const generateWithOpenAICompatible = async ({
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const systemPrompt = [
-        'You are an assistant writing pentest report finding content.',
-        field === 'references' ?
-            'Return ONLY valid JSON with one key: "references" as an array of concise strings.' :
-            `Return ONLY valid JSON with one key: "${field}" as HTML paragraphs using <p>...</p> without markdown fences.`
-    ].join(' ');
+    const systemPrompt = getSystemPrompt(outputType);
 
     const userPayload = {
-        field: field,
         promptInstruction: promptInstruction,
         context: context,
         userPrompt: userPrompt || ''
@@ -261,12 +219,12 @@ const generateWithOpenAICompatible = async ({
     if (!parsed) {
         throw({
             fn: 'BadRequest',
-            message: `${providerLabel} response does not contain valid JSON for "${field}"`
+            message: `${providerLabel} response does not contain valid JSON`
         });
     }
 
     return {
-        draft: getDraftFromParsed(field, parsed, providerLabel),
+        draft: getDraftFromParsed(outputType, parsed, providerLabel),
         model: payload?.model || model
     };
 }
@@ -284,11 +242,15 @@ const normalizeAnthropicContent = (content) => {
 }
 
 const generateWithAnthropic = async ({
-    field,
+    outputType,
     context = {},
     promptInstruction = '',
     userPrompt = '',
-    apiKey = ''
+    apiKey = '',
+    baseUrl,
+    model,
+    version,
+    timeoutMs
 }) => {
     if (!apiKey) {
         throw({
@@ -298,16 +260,10 @@ const generateWithAnthropic = async ({
     }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), ANTHROPIC_TIMEOUT_MS);
-    const systemPrompt = [
-        'You are an assistant writing pentest report finding content.',
-        field === 'references' ?
-            'Return ONLY valid JSON with one key: "references" as an array of concise strings.' :
-            `Return ONLY valid JSON with one key: "${field}" as HTML paragraphs using <p>...</p> without markdown fences.`
-    ].join(' ');
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const systemPrompt = getSystemPrompt(outputType);
 
     const userPayload = {
-        field: field,
         promptInstruction: promptInstruction,
         context: context,
         userPrompt: userPrompt || ''
@@ -315,16 +271,16 @@ const generateWithAnthropic = async ({
 
     let response = null;
     try {
-        response = await fetch(`${ANTHROPIC_BASE_URL}/messages`, {
+        response = await fetch(`${baseUrl}/messages`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'x-api-key': apiKey,
-                'anthropic-version': ANTHROPIC_VERSION
+                'anthropic-version': version
             },
             signal: controller.signal,
             body: JSON.stringify({
-                model: ANTHROPIC_MODEL,
+                model: model,
                 max_tokens: 1200,
                 temperature: 0.2,
                 system: systemPrompt,
@@ -340,7 +296,7 @@ const generateWithAnthropic = async ({
         if (err && err.name === 'AbortError') {
             throw({
                 fn: 'BadRequest',
-                message: `Anthropic request timed out after ${ANTHROPIC_TIMEOUT_MS}ms`
+                message: `Anthropic request timed out after ${timeoutMs}ms`
             });
         }
         throw({
@@ -368,27 +324,28 @@ const generateWithAnthropic = async ({
     if (!parsed) {
         throw({
             fn: 'BadRequest',
-            message: `Anthropic response does not contain valid JSON for "${field}"`
+            message: 'Anthropic response does not contain valid JSON'
         });
     }
 
     return {
-        draft: getDraftFromParsed(field, parsed, 'Anthropic'),
-        model: payload?.model || ANTHROPIC_MODEL
+        draft: getDraftFromParsed(outputType, parsed, 'Anthropic'),
+        model: payload?.model || model
     };
 }
 
 module.exports = function(app) {
     app.post('/api/ai/generate', acl.hasPermission('ai:generate'), async function(req, res) {
         try {
-            const field = req.body.field;
-            if (!field) {
-                Response.BadParameters(res, 'Missing required parameter: field');
+            const entityType = String(req.body.entityType || 'finding').trim().toLowerCase();
+            if (!['finding', 'section'].includes(entityType)) {
+                Response.BadParameters(res, `Unsupported entityType "${entityType}". Allowed entity types: finding, section`);
                 return;
             }
 
-            if (!SUPPORTED_FIELDS.includes(field)) {
-                Response.BadParameters(res, `Unsupported field "${field}". Allowed fields: ${SUPPORTED_FIELDS.join(', ')}`);
+            const field = String(req.body.field || '').trim();
+            if (!field) {
+                Response.BadParameters(res, 'Missing required parameter: field');
                 return;
             }
 
@@ -399,83 +356,123 @@ module.exports = function(app) {
                 settings = null;
             }
 
-            const prompts = getAiPromptsFromSettings(settings || {});
-            const promptInstruction = renderPromptTemplate(prompts[field], req.body.context || {});
-
-            const provider = normalizeProvider(req.body.provider) ||
-                normalizeProvider(settings?.ai?.public?.defaultProvider) ||
-                normalizeProvider(process.env.AI_PROVIDER) ||
-                'mock';
-
-            if (!SUPPORTED_PROVIDERS.includes(provider)) {
-                Response.BadParameters(res, `Unsupported provider "${provider}". Allowed providers: ${SUPPORTED_PROVIDERS.join(', ')}`);
+            if (!settings || settings?.ai?.public?.enabled === false) {
+                Response.Forbidden(res, 'AI integration is disabled in organization settings');
                 return;
             }
 
-            const openaiApiKey = (settings?.ai?.private?.openaiApiKey || process.env.AI_OPENAI_API_KEY || '').trim();
-            const anthropicApiKey = (settings?.ai?.private?.anthropicApiKey || process.env.AI_ANTHROPIC_API_KEY || '').trim();
-            const deepseekApiKey = (settings?.ai?.private?.deepseekApiKey || process.env.AI_DEEPSEEK_API_KEY || '').trim();
-            const ollamaApiKey = (settings?.ai?.private?.ollamaApiKey || process.env.AI_OLLAMA_API_KEY || '').trim();
-            const ollamaBaseUrl = toBaseUrl(settings?.ai?.private?.ollamaBaseUrl, OLLAMA_BASE_URL);
-            const ollamaModel = (settings?.ai?.private?.ollamaModel || OLLAMA_MODEL).trim() || OLLAMA_MODEL;
+            const customFields = await CustomField.getAll();
+            const fieldCatalog = buildAiFieldCatalog(customFields);
+            const fieldByCompositeKey = new Map(
+                fieldCatalog.map((entry) => [toPromptCompositeKey(entry.entityType, entry.fieldKey), entry])
+            );
+            const fieldConfig = fieldByCompositeKey.get(toPromptCompositeKey(entityType, field));
+
+            if (!fieldConfig) {
+                Response.BadParameters(res, `Unsupported field "${field}" for entityType "${entityType}"`);
+                return;
+            }
+
+            const promptDoc = await AiPrompt.findOne({
+                entityType: fieldConfig.entityType,
+                fieldKey: fieldConfig.fieldKey
+            }).select('enabled prompt').lean();
+            if (promptDoc && promptDoc.enabled === false) {
+                Response.Forbidden(res, `AI generation is disabled for field "${fieldConfig.fieldLabel}"`);
+                return;
+            }
+
+            const promptTemplate = normalizePromptValue(promptDoc?.prompt) || fieldConfig.defaultPrompt;
+            const promptInstruction = renderPromptTemplate(promptTemplate, req.body.context || {});
+
+            const provider = normalizeProvider(req.body.provider) ||
+                normalizeProvider(settings?.ai?.public?.defaultProvider) ||
+                AI_DEFAULT_PROVIDER;
+
+            if (!AI_PROVIDERS.includes(provider)) {
+                Response.BadParameters(res, `Unsupported provider "${provider}". Allowed providers: ${AI_PROVIDERS.join(', ')}`);
+                return;
+            }
+
+            const openaiApiKey = (settings?.ai?.private?.openaiApiKey || '').trim();
+            const openaiBaseUrl = toBaseUrl(settings?.ai?.private?.openaiBaseUrl, AI_PROVIDER_DEFAULTS.openai.baseUrl);
+            const openaiModel = (settings?.ai?.private?.openaiModel || AI_PROVIDER_DEFAULTS.openai.model).trim() || AI_PROVIDER_DEFAULTS.openai.model;
+            const openaiTimeoutMs = toTimeout(settings?.ai?.private?.openaiTimeoutMs, AI_PROVIDER_DEFAULTS.openai.timeoutMs);
+
+            const anthropicApiKey = (settings?.ai?.private?.anthropicApiKey || '').trim();
+            const anthropicBaseUrl = toBaseUrl(settings?.ai?.private?.anthropicBaseUrl, AI_PROVIDER_DEFAULTS.anthropic.baseUrl);
+            const anthropicModel = (settings?.ai?.private?.anthropicModel || AI_PROVIDER_DEFAULTS.anthropic.model).trim() || AI_PROVIDER_DEFAULTS.anthropic.model;
+            const anthropicVersion = (settings?.ai?.private?.anthropicVersion || AI_PROVIDER_DEFAULTS.anthropic.version).trim() || AI_PROVIDER_DEFAULTS.anthropic.version;
+            const anthropicTimeoutMs = toTimeout(settings?.ai?.private?.anthropicTimeoutMs, AI_PROVIDER_DEFAULTS.anthropic.timeoutMs);
+
+            const deepseekApiKey = (settings?.ai?.private?.deepseekApiKey || '').trim();
+            const deepseekBaseUrl = toBaseUrl(settings?.ai?.private?.deepseekBaseUrl, AI_PROVIDER_DEFAULTS.deepseek.baseUrl);
+            const deepseekModel = (settings?.ai?.private?.deepseekModel || AI_PROVIDER_DEFAULTS.deepseek.model).trim() || AI_PROVIDER_DEFAULTS.deepseek.model;
+            const deepseekTimeoutMs = toTimeout(settings?.ai?.private?.deepseekTimeoutMs, AI_PROVIDER_DEFAULTS.deepseek.timeoutMs);
+
+            const ollamaApiKey = (settings?.ai?.private?.ollamaApiKey || '').trim();
+            const ollamaBaseUrl = toBaseUrl(settings?.ai?.private?.ollamaBaseUrl, AI_PROVIDER_DEFAULTS.ollama.baseUrl);
+            const ollamaModel = (settings?.ai?.private?.ollamaModel || AI_PROVIDER_DEFAULTS.ollama.model).trim() || AI_PROVIDER_DEFAULTS.ollama.model;
+            const ollamaTimeoutMs = toTimeout(settings?.ai?.private?.ollamaTimeoutMs, AI_PROVIDER_DEFAULTS.ollama.timeoutMs);
 
             let result = null;
             if (provider === 'openai') {
                 result = await generateWithOpenAICompatible({
                     providerLabel: 'OpenAI',
-                    field: field,
+                    outputType: fieldConfig.outputType,
                     context: req.body.context || {},
                     promptInstruction: promptInstruction,
                     userPrompt: req.body.userPrompt || '',
                     apiKey: openaiApiKey,
-                    baseUrl: OPENAI_BASE_URL,
-                    model: OPENAI_MODEL,
-                    timeoutMs: OPENAI_TIMEOUT_MS,
+                    baseUrl: openaiBaseUrl,
+                    model: openaiModel,
+                    timeoutMs: openaiTimeoutMs,
                     requireApiKey: true
                 });
             } else if (provider === 'anthropic') {
                 result = await generateWithAnthropic({
-                    field: field,
+                    outputType: fieldConfig.outputType,
                     context: req.body.context || {},
                     promptInstruction: promptInstruction,
                     userPrompt: req.body.userPrompt || '',
-                    apiKey: anthropicApiKey
+                    apiKey: anthropicApiKey,
+                    baseUrl: anthropicBaseUrl,
+                    model: anthropicModel,
+                    version: anthropicVersion,
+                    timeoutMs: anthropicTimeoutMs
                 });
             } else if (provider === 'deepseek') {
                 result = await generateWithOpenAICompatible({
                     providerLabel: 'DeepSeek',
-                    field: field,
+                    outputType: fieldConfig.outputType,
                     context: req.body.context || {},
                     promptInstruction: promptInstruction,
                     userPrompt: req.body.userPrompt || '',
                     apiKey: deepseekApiKey,
-                    baseUrl: DEEPSEEK_BASE_URL,
-                    model: DEEPSEEK_MODEL,
-                    timeoutMs: DEEPSEEK_TIMEOUT_MS,
+                    baseUrl: deepseekBaseUrl,
+                    model: deepseekModel,
+                    timeoutMs: deepseekTimeoutMs,
                     requireApiKey: true
                 });
-            } else if (provider === 'ollama') {
+            } else {
                 result = await generateWithOpenAICompatible({
                     providerLabel: 'Ollama',
-                    field: field,
+                    outputType: fieldConfig.outputType,
                     context: req.body.context || {},
                     promptInstruction: promptInstruction,
                     userPrompt: req.body.userPrompt || '',
                     apiKey: ollamaApiKey,
                     baseUrl: ollamaBaseUrl,
                     model: ollamaModel,
-                    timeoutMs: OLLAMA_TIMEOUT_MS,
+                    timeoutMs: ollamaTimeoutMs,
                     requireApiKey: false
                 });
-            } else {
-                result = {
-                    draft: buildMockDraft(field, req.body.context || {}, promptInstruction, req.body.userPrompt || ''),
-                    model: 'pwndoc-template-v1'
-                };
             }
 
             Response.Ok(res, {
+                entityType: fieldConfig.entityType,
                 field: field,
+                outputType: fieldConfig.outputType,
                 draft: result.draft,
                 provider: provider,
                 model: result.model

--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -1,0 +1,487 @@
+const Response = require('../lib/httpResponse.js');
+const acl = require('../lib/auth').acl;
+const Settings = require('mongoose').model('Settings');
+const { getAiPromptsFromSettings } = require('../lib/ai-prompts');
+
+const toBaseUrl = (value, fallback) => String(value || fallback).replace(/\/+$/g, '');
+const toTimeout = (value, fallback) => {
+    const parsed = parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const OPENAI_BASE_URL = toBaseUrl(process.env.AI_OPENAI_BASE_URL, 'https://api.openai.com/v1');
+const OPENAI_MODEL = process.env.AI_OPENAI_MODEL || 'gpt-4.1-mini';
+const OPENAI_TIMEOUT_MS = toTimeout(process.env.AI_OPENAI_TIMEOUT_MS, 30000);
+
+const DEEPSEEK_BASE_URL = toBaseUrl(process.env.AI_DEEPSEEK_BASE_URL, 'https://api.deepseek.com/v1');
+const DEEPSEEK_MODEL = process.env.AI_DEEPSEEK_MODEL || 'deepseek-chat';
+const DEEPSEEK_TIMEOUT_MS = toTimeout(process.env.AI_DEEPSEEK_TIMEOUT_MS, 30000);
+
+const OLLAMA_BASE_URL = toBaseUrl(process.env.AI_OLLAMA_BASE_URL, 'http://localhost:11434/v1');
+const OLLAMA_MODEL = process.env.AI_OLLAMA_MODEL || 'llama3.1';
+const OLLAMA_TIMEOUT_MS = toTimeout(process.env.AI_OLLAMA_TIMEOUT_MS, 60000);
+
+const ANTHROPIC_BASE_URL = toBaseUrl(process.env.AI_ANTHROPIC_BASE_URL, 'https://api.anthropic.com/v1');
+const ANTHROPIC_MODEL = process.env.AI_ANTHROPIC_MODEL || 'claude-3-5-sonnet-latest';
+const ANTHROPIC_TIMEOUT_MS = toTimeout(process.env.AI_ANTHROPIC_TIMEOUT_MS, 30000);
+const ANTHROPIC_VERSION = process.env.AI_ANTHROPIC_VERSION || '2023-06-01';
+
+const SUPPORTED_FIELDS = ['description', 'observation', 'remediation', 'references'];
+const SUPPORTED_PROVIDERS = ['mock', 'openai', 'anthropic', 'deepseek', 'ollama'];
+
+const escapeHtml = (value = '') => {
+    return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const normalizeContextValue = (value) => {
+    if (value === null || value === undefined)
+        return '';
+    if (Array.isArray(value))
+        return value.join(', ');
+    return String(value);
+}
+
+const renderPromptTemplate = (template = '', context = {}) => {
+    const source = String(template || '');
+    return source.replace(/\{([a-zA-Z0-9_]+)\}/g, (match, key) => {
+        return normalizeContextValue(context[key]);
+    }).trim();
+}
+
+const toReferenceArray = (value) => {
+    if (Array.isArray(value)) {
+        return value.map((entry) => String(entry || '').trim()).filter(Boolean);
+    }
+    if (typeof value === 'string') {
+        return value
+        .split('\n')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    }
+    return [];
+}
+
+const uniqStrings = (values = []) => {
+    return [...new Set(values.map((value) => String(value).trim()).filter(Boolean))];
+}
+
+const buildMockDraft = (field, context = {}, promptInstruction = '', userPrompt = '') => {
+    const title = escapeHtml(context.title || 'the identified issue');
+    const vulnType = escapeHtml(context.vulnType || 'security');
+    const observation = escapeHtml(context.observation || '');
+    const description = escapeHtml(context.description || '');
+    const remediation = escapeHtml(context.remediation || '');
+    const prompt = escapeHtml(userPrompt || promptInstruction || '');
+
+    if (field === 'references') {
+        const output = [];
+        if (prompt)
+            output.push(prompt);
+        output.push(`OWASP Testing Guide - ${title}`);
+        if (vulnType)
+            output.push(`${vulnType} Security Verification Reference`);
+        return uniqStrings([...output, ...toReferenceArray(context.references)]).slice(0, 5);
+    }
+
+    const firstParagraph = prompt || `Draft for ${field} related to ${title}.`;
+    let secondParagraph = '';
+    if (field === 'description') {
+        secondParagraph = observation ?
+            `Observed behavior: ${observation}` :
+            'Further technical validation should document attack prerequisites and impact boundaries.';
+    } else if (field === 'observation') {
+        secondParagraph = description ?
+            `Context from description: ${description}` :
+            'Capture reproducible steps, affected components, and attacker-controlled conditions.';
+    } else if (field === 'remediation') {
+        secondParagraph = remediation ?
+            `Existing remediation notes: ${remediation}` :
+            'Prioritize practical controls, ownership, and verification steps to reduce risk.';
+    }
+
+    return `<p>${firstParagraph}</p><p>${secondParagraph}</p>`;
+}
+
+const normalizeProvider = (provider) => {
+    if (!provider || typeof provider !== 'string')
+        return null;
+    return provider.toLowerCase().trim();
+}
+
+const extractJsonObjectFromText = (text = '') => {
+    const trimmed = String(text || '').trim();
+    if (!trimmed)
+        return null;
+
+    const withoutFence = trimmed
+    .replace(/^```json\s*/i, '')
+    .replace(/^```\s*/i, '')
+    .replace(/\s*```$/i, '')
+    .trim();
+
+    try {
+        return JSON.parse(withoutFence);
+    } catch (_) {}
+
+    const jsonMatch = withoutFence.match(/\{[\s\S]*\}/);
+    if (!jsonMatch)
+        return null;
+
+    try {
+        return JSON.parse(jsonMatch[0]);
+    } catch (_) {
+        return null;
+    }
+}
+
+const getDraftFromParsed = (field, parsed = {}, providerLabel = 'AI provider') => {
+    if (field === 'references') {
+        const refs = toReferenceArray(parsed.references || parsed[field]);
+        if (refs.length === 0) {
+            throw({
+                fn: 'BadRequest',
+                message: `${providerLabel} response is missing valid references`
+            });
+        }
+        return refs;
+    }
+
+    const raw = parsed[field];
+    if (typeof raw !== 'string' || !raw.trim()) {
+        throw({
+            fn: 'BadRequest',
+            message: `${providerLabel} response is missing a valid "${field}" value`
+        });
+    }
+    return raw.trim();
+}
+
+const normalizeOpenAIContent = (content) => {
+    if (typeof content === 'string')
+        return content;
+    if (Array.isArray(content)) {
+        return content
+        .map((entry) => entry?.text || entry?.content || '')
+        .filter(Boolean)
+        .join('\n');
+    }
+    return '';
+}
+
+const generateWithOpenAICompatible = async ({
+    providerLabel,
+    field,
+    context = {},
+    promptInstruction = '',
+    userPrompt = '',
+    apiKey = '',
+    baseUrl,
+    model,
+    timeoutMs,
+    requireApiKey = true
+}) => {
+    if (requireApiKey && !apiKey) {
+        throw({
+            fn: 'BadParameters',
+            message: `${providerLabel} provider is not configured. Set API key.`
+        });
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const systemPrompt = [
+        'You are an assistant writing pentest report finding content.',
+        field === 'references' ?
+            'Return ONLY valid JSON with one key: "references" as an array of concise strings.' :
+            `Return ONLY valid JSON with one key: "${field}" as HTML paragraphs using <p>...</p> without markdown fences.`
+    ].join(' ');
+
+    const userPayload = {
+        field: field,
+        promptInstruction: promptInstruction,
+        context: context,
+        userPrompt: userPrompt || ''
+    };
+
+    const headers = {
+        'Content-Type': 'application/json'
+    };
+    if (apiKey)
+        headers.Authorization = `Bearer ${apiKey}`;
+
+    let response = null;
+    try {
+        response = await fetch(`${baseUrl}/chat/completions`, {
+            method: 'POST',
+            headers: headers,
+            signal: controller.signal,
+            body: JSON.stringify({
+                model: model,
+                temperature: 0.2,
+                messages: [
+                    {role: 'system', content: systemPrompt},
+                    {role: 'user', content: JSON.stringify(userPayload)}
+                ]
+            })
+        });
+    } catch (err) {
+        if (err && err.name === 'AbortError') {
+            throw({
+                fn: 'BadRequest',
+                message: `${providerLabel} request timed out after ${timeoutMs}ms`
+            });
+        }
+        throw({
+            fn: 'BadRequest',
+            message: `${providerLabel} request failed: ${err.message || String(err)}`
+        });
+    } finally {
+        clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+        let detail = '';
+        try {
+            detail = await response.text();
+        } catch (_) {}
+        throw({
+            fn: 'BadRequest',
+            message: `${providerLabel} returned HTTP ${response.status}${detail ? `: ${detail}` : ''}`
+        });
+    }
+
+    const payload = await response.json();
+    const content = normalizeOpenAIContent(payload?.choices?.[0]?.message?.content);
+    const parsed = extractJsonObjectFromText(content);
+    if (!parsed) {
+        throw({
+            fn: 'BadRequest',
+            message: `${providerLabel} response does not contain valid JSON for "${field}"`
+        });
+    }
+
+    return {
+        draft: getDraftFromParsed(field, parsed, providerLabel),
+        model: payload?.model || model
+    };
+}
+
+const normalizeAnthropicContent = (content) => {
+    if (typeof content === 'string')
+        return content;
+    if (Array.isArray(content)) {
+        return content
+        .filter((entry) => entry && entry.type === 'text' && entry.text)
+        .map((entry) => entry.text)
+        .join('\n');
+    }
+    return '';
+}
+
+const generateWithAnthropic = async ({
+    field,
+    context = {},
+    promptInstruction = '',
+    userPrompt = '',
+    apiKey = ''
+}) => {
+    if (!apiKey) {
+        throw({
+            fn: 'BadParameters',
+            message: 'Anthropic provider is not configured. Set API key.'
+        });
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ANTHROPIC_TIMEOUT_MS);
+    const systemPrompt = [
+        'You are an assistant writing pentest report finding content.',
+        field === 'references' ?
+            'Return ONLY valid JSON with one key: "references" as an array of concise strings.' :
+            `Return ONLY valid JSON with one key: "${field}" as HTML paragraphs using <p>...</p> without markdown fences.`
+    ].join(' ');
+
+    const userPayload = {
+        field: field,
+        promptInstruction: promptInstruction,
+        context: context,
+        userPrompt: userPrompt || ''
+    };
+
+    let response = null;
+    try {
+        response = await fetch(`${ANTHROPIC_BASE_URL}/messages`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-api-key': apiKey,
+                'anthropic-version': ANTHROPIC_VERSION
+            },
+            signal: controller.signal,
+            body: JSON.stringify({
+                model: ANTHROPIC_MODEL,
+                max_tokens: 1200,
+                temperature: 0.2,
+                system: systemPrompt,
+                messages: [
+                    {
+                        role: 'user',
+                        content: JSON.stringify(userPayload)
+                    }
+                ]
+            })
+        });
+    } catch (err) {
+        if (err && err.name === 'AbortError') {
+            throw({
+                fn: 'BadRequest',
+                message: `Anthropic request timed out after ${ANTHROPIC_TIMEOUT_MS}ms`
+            });
+        }
+        throw({
+            fn: 'BadRequest',
+            message: `Anthropic request failed: ${err.message || String(err)}`
+        });
+    } finally {
+        clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+        let detail = '';
+        try {
+            detail = await response.text();
+        } catch (_) {}
+        throw({
+            fn: 'BadRequest',
+            message: `Anthropic returned HTTP ${response.status}${detail ? `: ${detail}` : ''}`
+        });
+    }
+
+    const payload = await response.json();
+    const content = normalizeAnthropicContent(payload?.content);
+    const parsed = extractJsonObjectFromText(content);
+    if (!parsed) {
+        throw({
+            fn: 'BadRequest',
+            message: `Anthropic response does not contain valid JSON for "${field}"`
+        });
+    }
+
+    return {
+        draft: getDraftFromParsed(field, parsed, 'Anthropic'),
+        model: payload?.model || ANTHROPIC_MODEL
+    };
+}
+
+module.exports = function(app) {
+    app.post('/api/ai/generate', acl.hasPermission('ai:generate'), async function(req, res) {
+        try {
+            const field = req.body.field;
+            if (!field) {
+                Response.BadParameters(res, 'Missing required parameter: field');
+                return;
+            }
+
+            if (!SUPPORTED_FIELDS.includes(field)) {
+                Response.BadParameters(res, `Unsupported field "${field}". Allowed fields: ${SUPPORTED_FIELDS.join(', ')}`);
+                return;
+            }
+
+            let settings = null;
+            try {
+                settings = await Settings.getAll();
+            } catch (_) {
+                settings = null;
+            }
+
+            const prompts = getAiPromptsFromSettings(settings || {});
+            const promptInstruction = renderPromptTemplate(prompts[field], req.body.context || {});
+
+            const provider = normalizeProvider(req.body.provider) ||
+                normalizeProvider(settings?.ai?.public?.defaultProvider) ||
+                normalizeProvider(process.env.AI_PROVIDER) ||
+                'mock';
+
+            if (!SUPPORTED_PROVIDERS.includes(provider)) {
+                Response.BadParameters(res, `Unsupported provider "${provider}". Allowed providers: ${SUPPORTED_PROVIDERS.join(', ')}`);
+                return;
+            }
+
+            const openaiApiKey = (settings?.ai?.private?.openaiApiKey || process.env.AI_OPENAI_API_KEY || '').trim();
+            const anthropicApiKey = (settings?.ai?.private?.anthropicApiKey || process.env.AI_ANTHROPIC_API_KEY || '').trim();
+            const deepseekApiKey = (settings?.ai?.private?.deepseekApiKey || process.env.AI_DEEPSEEK_API_KEY || '').trim();
+            const ollamaApiKey = (settings?.ai?.private?.ollamaApiKey || process.env.AI_OLLAMA_API_KEY || '').trim();
+            const ollamaBaseUrl = toBaseUrl(settings?.ai?.private?.ollamaBaseUrl, OLLAMA_BASE_URL);
+            const ollamaModel = (settings?.ai?.private?.ollamaModel || OLLAMA_MODEL).trim() || OLLAMA_MODEL;
+
+            let result = null;
+            if (provider === 'openai') {
+                result = await generateWithOpenAICompatible({
+                    providerLabel: 'OpenAI',
+                    field: field,
+                    context: req.body.context || {},
+                    promptInstruction: promptInstruction,
+                    userPrompt: req.body.userPrompt || '',
+                    apiKey: openaiApiKey,
+                    baseUrl: OPENAI_BASE_URL,
+                    model: OPENAI_MODEL,
+                    timeoutMs: OPENAI_TIMEOUT_MS,
+                    requireApiKey: true
+                });
+            } else if (provider === 'anthropic') {
+                result = await generateWithAnthropic({
+                    field: field,
+                    context: req.body.context || {},
+                    promptInstruction: promptInstruction,
+                    userPrompt: req.body.userPrompt || '',
+                    apiKey: anthropicApiKey
+                });
+            } else if (provider === 'deepseek') {
+                result = await generateWithOpenAICompatible({
+                    providerLabel: 'DeepSeek',
+                    field: field,
+                    context: req.body.context || {},
+                    promptInstruction: promptInstruction,
+                    userPrompt: req.body.userPrompt || '',
+                    apiKey: deepseekApiKey,
+                    baseUrl: DEEPSEEK_BASE_URL,
+                    model: DEEPSEEK_MODEL,
+                    timeoutMs: DEEPSEEK_TIMEOUT_MS,
+                    requireApiKey: true
+                });
+            } else if (provider === 'ollama') {
+                result = await generateWithOpenAICompatible({
+                    providerLabel: 'Ollama',
+                    field: field,
+                    context: req.body.context || {},
+                    promptInstruction: promptInstruction,
+                    userPrompt: req.body.userPrompt || '',
+                    apiKey: ollamaApiKey,
+                    baseUrl: ollamaBaseUrl,
+                    model: ollamaModel,
+                    timeoutMs: OLLAMA_TIMEOUT_MS,
+                    requireApiKey: false
+                });
+            } else {
+                result = {
+                    draft: buildMockDraft(field, req.body.context || {}, promptInstruction, req.body.userPrompt || ''),
+                    model: 'pwndoc-template-v1'
+                };
+            }
+
+            Response.Ok(res, {
+                field: field,
+                draft: result.draft,
+                provider: provider,
+                model: result.model
+            });
+        } catch (err) {
+            Response.Internal(res, err);
+        }
+    });
+};

--- a/backend/src/routes/backup.js
+++ b/backend/src/routes/backup.js
@@ -27,6 +27,7 @@ module.exports = function(app) {
     const STATE_RESTORE_ERROR = 'restore_error'
 
     const Audit = require('mongoose').model('Audit');
+    const AiPrompt = require('mongoose').model('AiPrompt');
     const AuditType = require('mongoose').model('AuditType');
     const Client = require('mongoose').model('Client');
     const Company = require('mongoose').model('Company');
@@ -401,6 +402,7 @@ module.exports = function(app) {
             // Settings
             if (e === "Settings") {
                 backupPromises.push(Settings.backup(backupTmpPath))
+                backupPromises.push(AiPrompt.backup(backupTmpPath))
             }
         })
 
@@ -770,6 +772,7 @@ module.exports = function(app) {
             // Settings
             if (info.data.includes('Settings') && backupData.includes('Settings')) {
                 files.push('settings.json')
+                files.push('aiPrompts.json')
             }
 
             if (!fs.existsSync(restoreTmpPath))
@@ -839,6 +842,7 @@ module.exports = function(app) {
             // Settings
             if (info.data.includes('Settings') && backupData.includes('Settings')) {
                 restorePromises.push(Settings.restore(restoreTmpPath))
+                restorePromises.push(AiPrompt.restore(restoreTmpPath, restoreMode))
             }
             
             

--- a/backend/src/routes/data.js
+++ b/backend/src/routes/data.js
@@ -1,5 +1,3 @@
-const { isArray } = require('lodash');
-
 module.exports = function(app) {
 
     var Response = require('../lib/httpResponse.js');
@@ -11,13 +9,59 @@ module.exports = function(app) {
     var VulnerabilityCategory = require('mongoose').model('VulnerabilityCategory');
     var CustomSection = require('mongoose').model('CustomSection');
     var CustomField = require('mongoose').model('CustomField');
+    var AiPrompt = require('mongoose').model('AiPrompt');
     var Settings = require('mongoose').model('Settings');
-    const { getAiPromptsFromSettings, mergeWithDefaults } = require('../lib/ai-prompts');
-    const AI_PROVIDERS = ['mock', 'openai', 'anthropic', 'deepseek', 'ollama'];
-    const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434/v1';
-    const DEFAULT_OLLAMA_MODEL = 'llama3.1';
+    const {
+        AI_PROVIDERS,
+        AI_DEFAULT_PROVIDER,
+        AI_PROVIDER_DEFAULTS,
+        normalizePromptValue,
+        toPromptCompositeKey,
+        buildAiFieldCatalog,
+        buildPromptMappings
+    } = require('../lib/ai-prompts');
 
     var _ = require('lodash')
+
+    const getAiPromptsPayload = async (settings, isAdmin) => {
+        const aiSettings = settings?.ai || {};
+        const customFields = await CustomField.getAll();
+        const fieldCatalog = buildAiFieldCatalog(customFields);
+        const promptRows = await AiPrompt.find({}).select('entityType fieldKey fieldLabel outputType enabled prompt customFieldId').lean();
+
+        const promptMappings = buildPromptMappings(fieldCatalog, promptRows);
+        const defaultProvider = AI_PROVIDERS.includes(settings?.ai?.public?.defaultProvider) ?
+            settings.ai.public.defaultProvider :
+            AI_DEFAULT_PROVIDER;
+
+        const payload = {
+            aiEnabled: settings?.ai?.public?.enabled !== false,
+            defaultProvider: defaultProvider,
+            promptMappings: promptMappings
+        };
+
+        if (!isAdmin)
+            return payload;
+
+        payload.hasOpenAIApiKey = Boolean((aiSettings?.private?.openaiApiKey || '').trim());
+        payload.openaiBaseUrl = String(aiSettings?.private?.openaiBaseUrl || AI_PROVIDER_DEFAULTS.openai.baseUrl);
+        payload.openaiModel = String(aiSettings?.private?.openaiModel || AI_PROVIDER_DEFAULTS.openai.model);
+
+        payload.hasAnthropicApiKey = Boolean((aiSettings?.private?.anthropicApiKey || '').trim());
+        payload.anthropicBaseUrl = String(aiSettings?.private?.anthropicBaseUrl || AI_PROVIDER_DEFAULTS.anthropic.baseUrl);
+        payload.anthropicModel = String(aiSettings?.private?.anthropicModel || AI_PROVIDER_DEFAULTS.anthropic.model);
+        payload.anthropicVersion = String(aiSettings?.private?.anthropicVersion || AI_PROVIDER_DEFAULTS.anthropic.version);
+
+        payload.hasDeepseekApiKey = Boolean((aiSettings?.private?.deepseekApiKey || '').trim());
+        payload.deepseekBaseUrl = String(aiSettings?.private?.deepseekBaseUrl || AI_PROVIDER_DEFAULTS.deepseek.baseUrl);
+        payload.deepseekModel = String(aiSettings?.private?.deepseekModel || AI_PROVIDER_DEFAULTS.deepseek.model);
+
+        payload.hasOllamaApiKey = Boolean((aiSettings?.private?.ollamaApiKey || '').trim());
+        payload.ollamaBaseUrl = String(aiSettings?.private?.ollamaBaseUrl || AI_PROVIDER_DEFAULTS.ollama.baseUrl);
+        payload.ollamaModel = String(aiSettings?.private?.ollamaModel || AI_PROVIDER_DEFAULTS.ollama.model);
+
+        return payload;
+    }
 
 /* ===== ROLES ===== */
 
@@ -39,19 +83,8 @@ module.exports = function(app) {
         try {
             const settings = await Settings.getAll();
             const isAdmin = acl.isAllowed(req.decodedToken.role, 'settings:update');
-            const responsePayload = {
-                prompts: getAiPromptsFromSettings(settings),
-                defaultProvider: settings?.ai?.public?.defaultProvider || 'mock'
-            };
-            if (isAdmin) {
-                responsePayload.hasOpenAIApiKey = Boolean((settings?.ai?.private?.openaiApiKey || '').trim());
-                responsePayload.hasAnthropicApiKey = Boolean((settings?.ai?.private?.anthropicApiKey || '').trim());
-                responsePayload.hasDeepseekApiKey = Boolean((settings?.ai?.private?.deepseekApiKey || '').trim());
-                responsePayload.hasOllamaApiKey = Boolean((settings?.ai?.private?.ollamaApiKey || '').trim());
-                responsePayload.ollamaBaseUrl = String(settings?.ai?.private?.ollamaBaseUrl || DEFAULT_OLLAMA_BASE_URL);
-                responsePayload.ollamaModel = String(settings?.ai?.private?.ollamaModel || DEFAULT_OLLAMA_MODEL);
-            }
-            Response.Ok(res, responsePayload);
+            const payload = await getAiPromptsPayload(settings, isAdmin);
+            Response.Ok(res, payload);
         } catch (err) {
             Response.Internal(res, err);
         }
@@ -60,22 +93,16 @@ module.exports = function(app) {
     // Update AI prompts (admin only)
     app.put("/api/data/ai-prompts", acl.hasPermission('settings:update'), async function(req, res) {
         try {
-            const existingSettings = await Settings.getAll() || {};
-            const bodyPrompts = req.body.prompts;
-            if (bodyPrompts !== undefined && (typeof bodyPrompts !== 'object' || Array.isArray(bodyPrompts))) {
-                Response.BadParameters(res, 'Invalid prompts payload');
-                return;
-            }
+            let currentSettings = await Settings.getAll() || {};
+            const update = {$set: {}};
 
-            const mergedPrompts = mergeWithDefaults({
-                ...getAiPromptsFromSettings(existingSettings),
-                ...(bodyPrompts || {})
-            });
-            const update = {
-                $set: {
-                    'ai.public.prompts': mergedPrompts
+            if (req.body.aiEnabled !== undefined) {
+                if (typeof req.body.aiEnabled !== 'boolean') {
+                    Response.BadParameters(res, 'Invalid aiEnabled payload');
+                    return;
                 }
-            };
+                update.$set['ai.public.enabled'] = req.body.aiEnabled;
+            }
 
             if (req.body.defaultProvider !== undefined) {
                 const provider = String(req.body.defaultProvider || '').toLowerCase().trim();
@@ -112,12 +139,19 @@ module.exports = function(app) {
                 }
             }
 
-            const ollamaConfigFields = [
-                { bodyField: 'ollamaBaseUrl', settingsField: 'ai.private.ollamaBaseUrl', fallback: DEFAULT_OLLAMA_BASE_URL },
-                { bodyField: 'ollamaModel', settingsField: 'ai.private.ollamaModel', fallback: DEFAULT_OLLAMA_MODEL }
+            const providerConfigFields = [
+                { bodyField: 'openaiBaseUrl', settingsField: 'ai.private.openaiBaseUrl', fallback: AI_PROVIDER_DEFAULTS.openai.baseUrl },
+                { bodyField: 'openaiModel', settingsField: 'ai.private.openaiModel', fallback: AI_PROVIDER_DEFAULTS.openai.model },
+                { bodyField: 'anthropicBaseUrl', settingsField: 'ai.private.anthropicBaseUrl', fallback: AI_PROVIDER_DEFAULTS.anthropic.baseUrl },
+                { bodyField: 'anthropicModel', settingsField: 'ai.private.anthropicModel', fallback: AI_PROVIDER_DEFAULTS.anthropic.model },
+                { bodyField: 'anthropicVersion', settingsField: 'ai.private.anthropicVersion', fallback: AI_PROVIDER_DEFAULTS.anthropic.version },
+                { bodyField: 'deepseekBaseUrl', settingsField: 'ai.private.deepseekBaseUrl', fallback: AI_PROVIDER_DEFAULTS.deepseek.baseUrl },
+                { bodyField: 'deepseekModel', settingsField: 'ai.private.deepseekModel', fallback: AI_PROVIDER_DEFAULTS.deepseek.model },
+                { bodyField: 'ollamaBaseUrl', settingsField: 'ai.private.ollamaBaseUrl', fallback: AI_PROVIDER_DEFAULTS.ollama.baseUrl },
+                { bodyField: 'ollamaModel', settingsField: 'ai.private.ollamaModel', fallback: AI_PROVIDER_DEFAULTS.ollama.model }
             ];
 
-            for (const entry of ollamaConfigFields) {
+            for (const entry of providerConfigFields) {
                 if (!Object.prototype.hasOwnProperty.call(req.body, entry.bodyField))
                     continue;
 
@@ -131,22 +165,91 @@ module.exports = function(app) {
                 update.$set[entry.settingsField] = normalized || entry.fallback;
             }
 
-            const updatedSettings = await Settings.findOneAndUpdate({}, update, {
-                new: true,
-                runValidators: true,
-                upsert: true
-            });
+            if (Array.isArray(req.body.promptMappings)) {
+                const customFields = await CustomField.getAll();
+                const fieldCatalog = buildAiFieldCatalog(customFields);
+                const fieldByCompositeKey = new Map(
+                    fieldCatalog.map((field) => [toPromptCompositeKey(field.entityType, field.fieldKey), field])
+                );
+                const seenCompositeKeys = new Set();
+                const operations = [];
 
-            Response.Ok(res, {
-                prompts: getAiPromptsFromSettings(updatedSettings),
-                defaultProvider: updatedSettings?.ai?.public?.defaultProvider || 'mock',
-                hasOpenAIApiKey: Boolean((updatedSettings?.ai?.private?.openaiApiKey || '').trim()),
-                hasAnthropicApiKey: Boolean((updatedSettings?.ai?.private?.anthropicApiKey || '').trim()),
-                hasDeepseekApiKey: Boolean((updatedSettings?.ai?.private?.deepseekApiKey || '').trim()),
-                hasOllamaApiKey: Boolean((updatedSettings?.ai?.private?.ollamaApiKey || '').trim()),
-                ollamaBaseUrl: String(updatedSettings?.ai?.private?.ollamaBaseUrl || DEFAULT_OLLAMA_BASE_URL),
-                ollamaModel: String(updatedSettings?.ai?.private?.ollamaModel || DEFAULT_OLLAMA_MODEL)
-            });
+                for (const mapping of req.body.promptMappings) {
+                    if (!mapping || typeof mapping !== 'object') {
+                        Response.BadParameters(res, 'Invalid promptMappings payload');
+                        return;
+                    }
+
+                    const entityType = String(mapping.entityType || '').trim();
+                    const fieldKey = String(mapping.fieldKey || '').trim();
+                    const compositeKey = toPromptCompositeKey(entityType, fieldKey);
+                    if (!entityType || !fieldKey || !fieldByCompositeKey.has(compositeKey)) {
+                        Response.BadParameters(res, `Invalid prompt mapping: ${entityType || '(entityType missing)'} / ${fieldKey || '(fieldKey missing)'}`);
+                        return;
+                    }
+                    if (seenCompositeKeys.has(compositeKey))
+                        continue;
+
+                    seenCompositeKeys.add(compositeKey);
+                    const fieldMeta = fieldByCompositeKey.get(compositeKey);
+                    const prompt = normalizePromptValue(mapping.prompt);
+                    let enabled = true;
+                    if (Object.prototype.hasOwnProperty.call(mapping, 'enabled')) {
+                        if (typeof mapping.enabled !== 'boolean') {
+                            Response.BadParameters(res, `Invalid prompt enabled flag for: ${fieldMeta.entityType} / ${fieldMeta.fieldKey}`);
+                            return;
+                        }
+                        enabled = mapping.enabled;
+                    }
+                    operations.push({
+                        updateOne: {
+                            filter: {entityType: fieldMeta.entityType, fieldKey: fieldMeta.fieldKey},
+                            update: {
+                                $set: {
+                                    entityType: fieldMeta.entityType,
+                                    fieldKey: fieldMeta.fieldKey,
+                                    fieldLabel: fieldMeta.fieldLabel,
+                                    outputType: fieldMeta.outputType,
+                                    customFieldId: fieldMeta.customFieldId || null,
+                                    enabled: enabled,
+                                    prompt: prompt
+                                }
+                            },
+                            upsert: true
+                        }
+                    });
+                }
+
+                if (operations.length > 0)
+                    await AiPrompt.bulkWrite(operations);
+
+                const validCompositeKeys = new Set(Array.from(fieldByCompositeKey.keys()));
+                const existingRows = await AiPrompt.find({}).select('_id entityType fieldKey').lean();
+                const staleIds = existingRows
+                .filter((row) => !validCompositeKeys.has(toPromptCompositeKey(row.entityType, row.fieldKey)))
+                .map((row) => row._id);
+                if (staleIds.length > 0)
+                    await AiPrompt.deleteMany({_id: {$in: staleIds}});
+            } else if (req.body.promptMappings !== undefined) {
+                Response.BadParameters(res, 'Invalid promptMappings payload');
+                return;
+            }
+
+            if (!update.$set || Object.keys(update.$set).length === 0)
+                delete update.$set;
+            if (!update.$unset || Object.keys(update.$unset).length === 0)
+                delete update.$unset;
+
+            if (update.$set || update.$unset) {
+                currentSettings = await Settings.findOneAndUpdate({}, update, {
+                    new: true,
+                    runValidators: true,
+                    upsert: true
+                });
+            }
+
+            const payload = await getAiPromptsPayload(currentSettings, true);
+            Response.Ok(res, payload);
         } catch (err) {
             Response.Internal(res, err);
         }

--- a/backend/src/routes/data.js
+++ b/backend/src/routes/data.js
@@ -11,6 +11,11 @@ module.exports = function(app) {
     var VulnerabilityCategory = require('mongoose').model('VulnerabilityCategory');
     var CustomSection = require('mongoose').model('CustomSection');
     var CustomField = require('mongoose').model('CustomField');
+    var Settings = require('mongoose').model('Settings');
+    const { getAiPromptsFromSettings, mergeWithDefaults } = require('../lib/ai-prompts');
+    const AI_PROVIDERS = ['mock', 'openai', 'anthropic', 'deepseek', 'ollama'];
+    const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434/v1';
+    const DEFAULT_OLLAMA_MODEL = 'llama3.1';
 
     var _ = require('lodash')
 
@@ -26,6 +31,126 @@ module.exports = function(app) {
             Response.Internal(res, error)
         }
     })
+
+/* ===== AI PROMPTS ===== */
+
+    // Get AI prompts
+    app.get("/api/data/ai-prompts", acl.hasPermission('settings:read-public'), async function(req, res) {
+        try {
+            const settings = await Settings.getAll();
+            const isAdmin = acl.isAllowed(req.decodedToken.role, 'settings:update');
+            const responsePayload = {
+                prompts: getAiPromptsFromSettings(settings),
+                defaultProvider: settings?.ai?.public?.defaultProvider || 'mock'
+            };
+            if (isAdmin) {
+                responsePayload.hasOpenAIApiKey = Boolean((settings?.ai?.private?.openaiApiKey || '').trim());
+                responsePayload.hasAnthropicApiKey = Boolean((settings?.ai?.private?.anthropicApiKey || '').trim());
+                responsePayload.hasDeepseekApiKey = Boolean((settings?.ai?.private?.deepseekApiKey || '').trim());
+                responsePayload.hasOllamaApiKey = Boolean((settings?.ai?.private?.ollamaApiKey || '').trim());
+                responsePayload.ollamaBaseUrl = String(settings?.ai?.private?.ollamaBaseUrl || DEFAULT_OLLAMA_BASE_URL);
+                responsePayload.ollamaModel = String(settings?.ai?.private?.ollamaModel || DEFAULT_OLLAMA_MODEL);
+            }
+            Response.Ok(res, responsePayload);
+        } catch (err) {
+            Response.Internal(res, err);
+        }
+    });
+
+    // Update AI prompts (admin only)
+    app.put("/api/data/ai-prompts", acl.hasPermission('settings:update'), async function(req, res) {
+        try {
+            const existingSettings = await Settings.getAll() || {};
+            const bodyPrompts = req.body.prompts;
+            if (bodyPrompts !== undefined && (typeof bodyPrompts !== 'object' || Array.isArray(bodyPrompts))) {
+                Response.BadParameters(res, 'Invalid prompts payload');
+                return;
+            }
+
+            const mergedPrompts = mergeWithDefaults({
+                ...getAiPromptsFromSettings(existingSettings),
+                ...(bodyPrompts || {})
+            });
+            const update = {
+                $set: {
+                    'ai.public.prompts': mergedPrompts
+                }
+            };
+
+            if (req.body.defaultProvider !== undefined) {
+                const provider = String(req.body.defaultProvider || '').toLowerCase().trim();
+                if (!AI_PROVIDERS.includes(provider)) {
+                    Response.BadParameters(res, `Invalid defaultProvider. Allowed values: ${AI_PROVIDERS.join(', ')}`);
+                    return;
+                }
+                update.$set['ai.public.defaultProvider'] = provider;
+            }
+
+            const apiKeyFields = [
+                { bodyField: 'openaiApiKey', settingsField: 'ai.private.openaiApiKey' },
+                { bodyField: 'anthropicApiKey', settingsField: 'ai.private.anthropicApiKey' },
+                { bodyField: 'deepseekApiKey', settingsField: 'ai.private.deepseekApiKey' },
+                { bodyField: 'ollamaApiKey', settingsField: 'ai.private.ollamaApiKey' }
+            ];
+
+            for (const entry of apiKeyFields) {
+                if (!Object.prototype.hasOwnProperty.call(req.body, entry.bodyField))
+                    continue;
+
+                const keyValue = req.body[entry.bodyField];
+                if (typeof keyValue !== 'string') {
+                    Response.BadParameters(res, `Invalid ${entry.bodyField} payload`);
+                    return;
+                }
+
+                const apiKey = keyValue.trim();
+                if (apiKey) {
+                    update.$set[entry.settingsField] = apiKey;
+                } else {
+                    update.$unset = update.$unset || {};
+                    update.$unset[entry.settingsField] = 1;
+                }
+            }
+
+            const ollamaConfigFields = [
+                { bodyField: 'ollamaBaseUrl', settingsField: 'ai.private.ollamaBaseUrl', fallback: DEFAULT_OLLAMA_BASE_URL },
+                { bodyField: 'ollamaModel', settingsField: 'ai.private.ollamaModel', fallback: DEFAULT_OLLAMA_MODEL }
+            ];
+
+            for (const entry of ollamaConfigFields) {
+                if (!Object.prototype.hasOwnProperty.call(req.body, entry.bodyField))
+                    continue;
+
+                const value = req.body[entry.bodyField];
+                if (typeof value !== 'string') {
+                    Response.BadParameters(res, `Invalid ${entry.bodyField} payload`);
+                    return;
+                }
+
+                const normalized = value.trim();
+                update.$set[entry.settingsField] = normalized || entry.fallback;
+            }
+
+            const updatedSettings = await Settings.findOneAndUpdate({}, update, {
+                new: true,
+                runValidators: true,
+                upsert: true
+            });
+
+            Response.Ok(res, {
+                prompts: getAiPromptsFromSettings(updatedSettings),
+                defaultProvider: updatedSettings?.ai?.public?.defaultProvider || 'mock',
+                hasOpenAIApiKey: Boolean((updatedSettings?.ai?.private?.openaiApiKey || '').trim()),
+                hasAnthropicApiKey: Boolean((updatedSettings?.ai?.private?.anthropicApiKey || '').trim()),
+                hasDeepseekApiKey: Boolean((updatedSettings?.ai?.private?.deepseekApiKey || '').trim()),
+                hasOllamaApiKey: Boolean((updatedSettings?.ai?.private?.ollamaApiKey || '').trim()),
+                ollamaBaseUrl: String(updatedSettings?.ai?.private?.ollamaBaseUrl || DEFAULT_OLLAMA_BASE_URL),
+                ollamaModel: String(updatedSettings?.ai?.private?.ollamaModel || DEFAULT_OLLAMA_MODEL)
+            });
+        } catch (err) {
+            Response.Internal(res, err);
+        }
+    });
 
 /* ===== LANGUAGES ===== */
 

--- a/backend/tests/lib.test.js
+++ b/backend/tests/lib.test.js
@@ -537,10 +537,25 @@ module.exports = function () {
             `<w:pStyle w:val="Code"/>`+
           `</w:pPr>`+
           `<w:r>`+
+            `<w:t xml:space="preserve">Code Block</w:t>`+
+          `</w:r>`+
+        `</w:p>`
+        var ooxml = html2ooxml(html)
+        expect(ooxml).toEqual(expected)
+      })
+
+      it('Inline code uses CodeChar', () => {
+        var html = "<p>Text with <code>inline code</code></p>"
+        var expected =
+        `<w:p>`+
+          `<w:r>`+
+            `<w:t xml:space="preserve">Text with </w:t>`+
+          `</w:r>`+
+          `<w:r>`+
             `<w:rPr>`+
               `<w:rStyle w:val="CodeChar"/>`+
             `</w:rPr>`+
-            `<w:t xml:space="preserve">Code Block</w:t>`+
+            `<w:t xml:space="preserve">inline code</w:t>`+
           `</w:r>`+
         `</w:p>`
         var ooxml = html2ooxml(html)

--- a/backend/tests/settings.test.js
+++ b/backend/tests/settings.test.js
@@ -6,7 +6,31 @@ module.exports = function(request, app) {
         userToken = response.body.datas.token
       })
 
+      const defaultAiPublicSettings = {
+        "enabled": true,
+        "defaultProvider": "openai"
+      }
+
+      const defaultAiPrivateSettings = {
+        "openaiApiKey": "",
+        "openaiBaseUrl": "https://api.openai.com/v1",
+        "openaiModel": "gpt-4.1-mini",
+        "anthropicApiKey": "",
+        "anthropicBaseUrl": "https://api.anthropic.com/v1",
+        "anthropicModel": "claude-3-5-sonnet-latest",
+        "anthropicVersion": "2023-06-01",
+        "deepseekApiKey": "",
+        "deepseekBaseUrl": "https://api.deepseek.com/v1",
+        "deepseekModel": "deepseek-chat",
+        "ollamaApiKey": "",
+        "ollamaBaseUrl": "http://localhost:11434/v1",
+        "ollamaModel": "llama3.1"
+      }
+
       const defaultPublicSettings = {
+        "ai": {
+          "public": defaultAiPublicSettings,
+        },
         "report": {
             "enabled": true,
             "public": {
@@ -56,6 +80,10 @@ module.exports = function(request, app) {
       }
 
       const defaultSettings = {
+        "ai": {
+          "private": defaultAiPrivateSettings,
+          "public": defaultAiPublicSettings,
+        },
         "report": {
             "enabled": true,
             "private": {
@@ -133,6 +161,10 @@ module.exports = function(request, app) {
 
       it('Edit settings', async () => {
         const fullModification = {
+          "ai": {
+            "private": defaultAiPrivateSettings,
+            "public": defaultAiPublicSettings,
+          },
           "report": {
               "enabled": false,
               "private": {

--- a/frontend/src/components/custom-fields.vue
+++ b/frontend/src/components/custom-fields.vue
@@ -22,23 +22,37 @@
                 :model-value="field.text"
                 >
                     <template v-slot:control>
-                        <basic-editor 
-                        v-if="diff"
-                        v-model="field.text"
-                        :diff="getTextDiffInCustomFields(field)"
-                        :editable=false
-                        /> 
-                        <basic-editor 
-                        v-else
-                        ref="basiceditor_custom" 
-                        v-model="field.text" 
-                        :noSync="noSyncEditor"
-                        :editable="!readonly"
-                        :fieldName="`field-${field.customField.label}`"
-                        :commentMode="commentMode && canCreateComment"
-                        :focusedComment="focusedComment"
-                        :commentIdList="commentIdList"
-                        /> 
+                        <div class="custom-editor-wrap">
+                            <q-btn
+                            v-if="showAiButton(field)"
+                            class="custom-field-ai-btn all-pointer-events"
+                            size="sm"
+                            unelevated
+                            no-caps
+                            color="secondary"
+                            :loading="isAiLoading(field)"
+                            :disable="readonly || isAiLoading(field)"
+                            label="AI"
+                            @click.stop="triggerGenerateAi(field)"
+                            />
+                            <basic-editor 
+                            v-if="diff"
+                            v-model="field.text"
+                            :diff="getTextDiffInCustomFields(field)"
+                            :editable=false
+                            /> 
+                            <basic-editor 
+                            v-else
+                            ref="basiceditor_custom" 
+                            v-model="field.text" 
+                            :noSync="noSyncEditor"
+                            :editable="!readonly"
+                            :fieldName="`field-${field.customField.label}`"
+                            :commentMode="commentMode && canCreateComment"
+                            :focusedComment="focusedComment"
+                            :commentIdList="commentIdList"
+                            /> 
+                        </div>
                     </template>
 
                     <template v-slot:label>
@@ -62,6 +76,20 @@
                 lazy-rules="ondemand"
                 outlined
                 >
+                    <template v-slot:append>
+                        <q-btn
+                        v-if="showAiButton(field)"
+                        class="all-pointer-events"
+                        size="sm"
+                        unelevated
+                        no-caps
+                        color="secondary"
+                        :loading="isAiLoading(field)"
+                        :disable="readonly || isAiLoading(field)"
+                        label="AI"
+                        @click.stop="triggerGenerateAi(field)"
+                        />
+                    </template>
                     <template v-slot:label>
                         {{field.customField.label}} <span v-if="field.customField.required" class="text-red">*</span>
                     </template>
@@ -87,6 +115,18 @@
                 outlined
                 >
                     <template v-slot:append>
+                        <q-btn
+                        v-if="showAiButton(field)"
+                        class="all-pointer-events"
+                        size="sm"
+                        unelevated
+                        no-caps
+                        color="secondary"
+                        :loading="isAiLoading(field)"
+                        :disable="readonly || isAiLoading(field)"
+                        label="AI"
+                        @click.stop="triggerGenerateAi(field)"
+                        />
                         <q-icon name="event" class="cursor-pointer">
                         <q-popup-proxy ref="qDateProxyField" transition-show="scale" transition-hide="scale">
                             <q-date :readonly="readonly" first-day-of-week="1" mask="YYYY-MM-DD" v-model="field.text" @update:model-value="$refs.qDateProxyField.forEach(e => e.hide())" />
@@ -124,6 +164,20 @@
                 :rules="(field.customField.required)? [val => !!val || 'Field is required']: []"
                 lazy-rules="ondemand"
                 >
+                     <template v-slot:append>
+                        <q-btn
+                        v-if="showAiButton(field)"
+                        class="all-pointer-events"
+                        size="sm"
+                        unelevated
+                        no-caps
+                        color="secondary"
+                        :loading="isAiLoading(field)"
+                        :disable="readonly || isAiLoading(field)"
+                        label="AI"
+                        @click.stop="triggerGenerateAi(field)"
+                        />
+                    </template>
                      <template v-slot:label>
                         {{field.customField.label}} <span v-if="field.customField.required" class="text-red">*</span>
                     </template>
@@ -157,6 +211,20 @@
                 :rules="(field.customField.required)? [val => !!val || 'Field is required', val => val && val.length > 0 || 'Field is required']: []"
                 lazy-rules="ondemand"
                 >
+                     <template v-slot:append>
+                        <q-btn
+                        v-if="showAiButton(field)"
+                        class="all-pointer-events"
+                        size="sm"
+                        unelevated
+                        no-caps
+                        color="secondary"
+                        :loading="isAiLoading(field)"
+                        :disable="readonly || isAiLoading(field)"
+                        label="AI"
+                        @click.stop="triggerGenerateAi(field)"
+                        />
+                    </template>
                      <template v-slot:label>
                         {{field.customField.label}} <span v-if="field.customField.required" class="text-red">*</span>
                     </template>
@@ -194,6 +262,20 @@
                 :rules="(field.customField.required)? [val => !!val || 'Field is required', val => val && val.length > 0 || 'Field is required']: []"
                 lazy-rules="ondemand"
                 >
+                    <template v-slot:append>
+                        <q-btn
+                        v-if="showAiButton(field)"
+                        class="all-pointer-events"
+                        size="sm"
+                        unelevated
+                        no-caps
+                        color="secondary"
+                        :loading="isAiLoading(field)"
+                        :disable="readonly || isAiLoading(field)"
+                        label="AI"
+                        @click.stop="triggerGenerateAi(field)"
+                        />
+                    </template>
                     <template v-slot:control>
                         <q-option-group
                         type="checkbox"
@@ -228,6 +310,20 @@
                 :rules="(field.customField.required)? [val => !!val || 'Field is required']: []"
                 lazy-rules="ondemand"
                 >
+                    <template v-slot:append>
+                        <q-btn
+                        v-if="showAiButton(field)"
+                        class="all-pointer-events"
+                        size="sm"
+                        unelevated
+                        no-caps
+                        color="secondary"
+                        :loading="isAiLoading(field)"
+                        :disable="readonly || isAiLoading(field)"
+                        label="AI"
+                        @click.stop="triggerGenerateAi(field)"
+                        />
+                    </template>
                     <template v-slot:control>
                         <q-option-group
                         type="radio"
@@ -300,6 +396,22 @@ export default {
         canCreateComment: {
             type: Boolean,
             default: false
+        },
+        aiEnabled: {
+            type: Boolean,
+            default: false
+        },
+        canGenerateAiForField: {
+            type: Function,
+            default: () => false
+        },
+        isAiGeneratingField: {
+            type: Function,
+            default: () => false
+        },
+        generateAiForField: {
+            type: Function,
+            default: () => {}
         }
     },
 
@@ -354,6 +466,22 @@ export default {
             return result
         },
 
+        getAiFieldKey: function(field) {
+            return `custom-field:${field.customField._id}`
+        },
+
+        showAiButton: function(field) {
+            return this.aiEnabled && this.canGenerateAiForField(this.getAiFieldKey(field))
+        },
+
+        isAiLoading: function(field) {
+            return this.isAiGeneratingField(this.getAiFieldKey(field))
+        },
+
+        triggerGenerateAi: function(field) {
+            this.generateAiForField(field)
+        },
+
         validate: function() {
             Object.keys(this.$refs).forEach(key => key.startsWith('field') && this.$refs[key][0].validate())
         },
@@ -373,5 +501,20 @@ export default {
 
 </script>
 
-<style>
+<style scoped>
+.custom-editor-wrap {
+    position: relative;
+    width: 100%;
+}
+
+.custom-field-ai-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 5;
+}
+
+.custom-field-ai-btn :deep(.q-btn__content) {
+    font-weight: 600;
+}
 </style>

--- a/frontend/src/pages/audits/edit/findings/edit/edit.js
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.js
@@ -31,12 +31,9 @@ export default {
             AUDIT_VIEW_STATE: Utils.AUDIT_VIEW_STATE,
             overrideLeaveCheck: false,
             transitionEnd: true,
-            aiGeneratingFields: {
-                description: false,
-                observation: false,
-                remediation: false,
-                references: false
-            },
+            aiEnabled: false,
+            aiPromptFieldKeys: [],
+            aiGeneratingFields: {},
             // Comments
             commentTemp: null,
             replyTemp: null,
@@ -82,6 +79,7 @@ export default {
         this.findingId = this.$route.params.findingId;
         this.getFinding();
         this.getVulnTypes();
+        this.getAiPromptsConfig();
 
         this.$socket.emit('menu', {menu: 'editFinding', finding: this.findingId, room: this.auditId});
 
@@ -214,6 +212,21 @@ export default {
             })
             .catch((err) => {
                 console.log(err)
+            })
+        },
+
+        getAiPromptsConfig: function() {
+            DataService.getAiPrompts()
+            .then((data) => {
+                const payload = data.data.datas || {}
+                this.aiEnabled = payload.aiEnabled !== false
+                this.aiPromptFieldKeys = (payload.promptMappings || [])
+                .filter((mapping) => String(mapping.entityType || '') === 'finding' && mapping.enabled !== false)
+                .map((mapping) => String(mapping.fieldKey || ''))
+            })
+            .catch(() => {
+                this.aiEnabled = false
+                this.aiPromptFieldKeys = []
             })
         },
 
@@ -354,29 +367,49 @@ export default {
             })
         },
 
-        isAiFieldLoading: function(field) {
-            return !!this.aiGeneratingFields[field]
+        getCustomFieldAiKey: function(customFieldId) {
+            return `custom-field:${customFieldId}`
+        },
+
+        canGenerateAi: function(fieldKey) {
+            return this.aiEnabled && this.aiPromptFieldKeys.includes(fieldKey)
+        },
+
+        isAiFieldLoading: function(fieldKey) {
+            return !!this.aiGeneratingFields[fieldKey]
         },
 
         generateDescriptionDraftAI: function() {
             return this.generateFieldDraftAI('description')
         },
 
-        generateFieldDraftAI: async function(field) {
-            const supportedFields = ['description', 'observation', 'remediation', 'references']
-            if (!supportedFields.includes(field))
+        generateCustomFieldDraftAI: function(customField) {
+            return this.generateFieldDraftAI(null, customField)
+        },
+
+        generateFieldDraftAI: async function(field, customField = null) {
+            const fieldKey = customField ? this.getCustomFieldAiKey(customField?.customField?._id) : field
+            if (!fieldKey || !this.canGenerateAi(fieldKey))
                 return
 
-            if (this.frontEndAuditState !== this.AUDIT_VIEW_STATE.EDIT || this.isAiFieldLoading(field))
+            if (this.frontEndAuditState !== this.AUDIT_VIEW_STATE.EDIT || this.isAiFieldLoading(fieldKey))
                 return
 
             Utils.syncEditors(this.$refs)
-            this.aiGeneratingFields[field] = true
+            this.aiGeneratingFields[fieldKey] = true
 
             try {
+                const customFieldContext = {}
+                if (this.finding.customFields && this.finding.customFields.length > 0) {
+                    this.finding.customFields.forEach((entry) => {
+                        if (entry?.customField?.label)
+                            customFieldContext[entry.customField.label] = entry.text
+                    })
+                }
+
                 const response = await AiService.generateFieldDraft({
                     entityType: 'finding',
-                    field: field,
+                    field: fieldKey,
                     locale: this.auditParent.language,
                     context: {
                         title: this.finding.title || '',
@@ -384,37 +417,62 @@ export default {
                         observation: this.finding.observation || '',
                         description: this.finding.description || '',
                         remediation: this.finding.remediation || '',
-                        references: this.finding.references || []
+                        references: this.finding.references || [],
+                        poc: this.finding.poc || '',
+                        scope: this.finding.scope || '',
+                        customFieldLabel: customField?.customField?.label || '',
+                        customFieldValue: customField?.text || '',
+                        customFields: customFieldContext
                     }
                 })
 
                 const rawDraft = response.data?.datas?.draft || ''
+                const outputType = response.data?.datas?.outputType || ((field === 'references') ? 'array' : 'html')
                 const providerUsed = response.data?.datas?.provider || 'default provider'
-                if (field === 'references') {
+                let normalizedDraft = null
+
+                if (outputType === 'array') {
                     const references = Array.isArray(rawDraft)
                         ? rawDraft
                         : String(rawDraft).split('\n')
 
-                    const normalized = references
+                    normalizedDraft = references
                     .map(e => String(e || '').trim())
                     .filter(Boolean)
 
-                    if (normalized.length === 0)
+                    if (normalizedDraft.length === 0)
                         throw new Error('AI draft is empty')
+                } else {
+                    normalizedDraft = String(rawDraft || '').trim()
+                    if (!normalizedDraft)
+                        throw new Error('AI draft is empty')
+                }
 
-                    const preview = normalized
+                const fieldLabel = customField?.customField?.label || ({
+                    description: 'Description',
+                    observation: 'Observation',
+                    remediation: 'Remediation',
+                    references: 'References',
+                    poc: 'Proofs'
+                }[field] || fieldKey)
+
+                if (outputType === 'array') {
+                    const preview = normalizedDraft
                     .map(line => line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'))
                     .join('<br/>')
 
                     Dialog.create({
-                        title: `AI Draft - References (${providerUsed})`,
+                        title: `AI Draft - ${fieldLabel} (${providerUsed})`,
                         html: true,
-                        message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${preview}</div><p class="q-mt-md">Apply this draft to the References field?</p>`,
+                        message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${preview}</div><p class="q-mt-md">Apply this draft to the ${fieldLabel} field?</p>`,
                         ok: {label: 'Apply', color: 'primary'},
                         cancel: {label: $t('btn.cancel'), color: 'white'}
                     })
                     .onOk(() => {
-                        this.finding.references = normalized
+                        if (customField)
+                            customField.text = normalizedDraft
+                        else
+                            this.finding[field] = normalizedDraft
                         Notify.create({
                             message: `AI draft applied from ${providerUsed} (not saved yet)`,
                             color: 'positive',
@@ -425,19 +483,23 @@ export default {
                     return
                 }
 
-                const draft = Utils.htmlEncode(String(rawDraft))
-                if (!draft)
-                    throw new Error('AI draft is empty')
+                const preview = (outputType === 'html') ?
+                    Utils.htmlEncode(normalizedDraft) :
+                    normalizedDraft.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
                 Dialog.create({
-                    title: `AI Draft - ${field.charAt(0).toUpperCase() + field.slice(1)} (${providerUsed})`,
+                    title: `AI Draft - ${fieldLabel} (${providerUsed})`,
                     html: true,
-                    message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${draft}</div><p class="q-mt-md">Apply this draft to the ${field} field?</p>`,
+                    message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${preview}</div><p class="q-mt-md">Apply this draft to the ${fieldLabel} field?</p>`,
                     ok: {label: 'Apply', color: 'primary'},
                     cancel: {label: $t('btn.cancel'), color: 'white'}
                 })
                 .onOk(() => {
-                    this.finding[field] = draft
+                    const appliedDraft = (outputType === 'html') ? Utils.htmlEncode(normalizedDraft) : normalizedDraft
+                    if (customField)
+                        customField.text = appliedDraft
+                    else
+                        this.finding[field] = appliedDraft
                     Notify.create({
                         message: `AI draft applied from ${providerUsed} (not saved yet)`,
                         color: 'positive',
@@ -453,7 +515,7 @@ export default {
                     position: 'top-right'
                 })
             } finally {
-                this.aiGeneratingFields[field] = false
+                this.aiGeneratingFields[fieldKey] = false
             }
         },
 

--- a/frontend/src/pages/audits/edit/findings/edit/edit.js
+++ b/frontend/src/pages/audits/edit/findings/edit/edit.js
@@ -12,6 +12,7 @@ import AuditService from '@/services/audit';
 import DataService from '@/services/data';
 import { useUserStore } from 'src/stores/user'
 import VulnService from '@/services/vulnerability';
+import AiService from '@/services/ai';
 import Utils from '@/services/utils';
 
 import { $t } from '@/boot/i18n'
@@ -30,6 +31,12 @@ export default {
             AUDIT_VIEW_STATE: Utils.AUDIT_VIEW_STATE,
             overrideLeaveCheck: false,
             transitionEnd: true,
+            aiGeneratingFields: {
+                description: false,
+                observation: false,
+                remediation: false,
+                references: false
+            },
             // Comments
             commentTemp: null,
             replyTemp: null,
@@ -345,6 +352,109 @@ export default {
                     position: 'top-right'
                 })
             })
+        },
+
+        isAiFieldLoading: function(field) {
+            return !!this.aiGeneratingFields[field]
+        },
+
+        generateDescriptionDraftAI: function() {
+            return this.generateFieldDraftAI('description')
+        },
+
+        generateFieldDraftAI: async function(field) {
+            const supportedFields = ['description', 'observation', 'remediation', 'references']
+            if (!supportedFields.includes(field))
+                return
+
+            if (this.frontEndAuditState !== this.AUDIT_VIEW_STATE.EDIT || this.isAiFieldLoading(field))
+                return
+
+            Utils.syncEditors(this.$refs)
+            this.aiGeneratingFields[field] = true
+
+            try {
+                const response = await AiService.generateFieldDraft({
+                    entityType: 'finding',
+                    field: field,
+                    locale: this.auditParent.language,
+                    context: {
+                        title: this.finding.title || '',
+                        vulnType: this.finding.vulnType || '',
+                        observation: this.finding.observation || '',
+                        description: this.finding.description || '',
+                        remediation: this.finding.remediation || '',
+                        references: this.finding.references || []
+                    }
+                })
+
+                const rawDraft = response.data?.datas?.draft || ''
+                const providerUsed = response.data?.datas?.provider || 'default provider'
+                if (field === 'references') {
+                    const references = Array.isArray(rawDraft)
+                        ? rawDraft
+                        : String(rawDraft).split('\n')
+
+                    const normalized = references
+                    .map(e => String(e || '').trim())
+                    .filter(Boolean)
+
+                    if (normalized.length === 0)
+                        throw new Error('AI draft is empty')
+
+                    const preview = normalized
+                    .map(line => line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'))
+                    .join('<br/>')
+
+                    Dialog.create({
+                        title: `AI Draft - References (${providerUsed})`,
+                        html: true,
+                        message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${preview}</div><p class="q-mt-md">Apply this draft to the References field?</p>`,
+                        ok: {label: 'Apply', color: 'primary'},
+                        cancel: {label: $t('btn.cancel'), color: 'white'}
+                    })
+                    .onOk(() => {
+                        this.finding.references = normalized
+                        Notify.create({
+                            message: `AI draft applied from ${providerUsed} (not saved yet)`,
+                            color: 'positive',
+                            textColor: 'white',
+                            position: 'top-right'
+                        })
+                    })
+                    return
+                }
+
+                const draft = Utils.htmlEncode(String(rawDraft))
+                if (!draft)
+                    throw new Error('AI draft is empty')
+
+                Dialog.create({
+                    title: `AI Draft - ${field.charAt(0).toUpperCase() + field.slice(1)} (${providerUsed})`,
+                    html: true,
+                    message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${draft}</div><p class="q-mt-md">Apply this draft to the ${field} field?</p>`,
+                    ok: {label: 'Apply', color: 'primary'},
+                    cancel: {label: $t('btn.cancel'), color: 'white'}
+                })
+                .onOk(() => {
+                    this.finding[field] = draft
+                    Notify.create({
+                        message: `AI draft applied from ${providerUsed} (not saved yet)`,
+                        color: 'positive',
+                        textColor: 'white',
+                        position: 'top-right'
+                    })
+                })
+            } catch (err) {
+                Notify.create({
+                    message: err.response?.data?.datas || err.message || 'Unable to generate AI draft',
+                    color: 'negative',
+                    textColor: 'white',
+                    position: 'top-right'
+                })
+            } finally {
+                this.aiGeneratingFields[field] = false
+            }
         },
 
         syncEditors: function() {

--- a/frontend/src/pages/audits/edit/findings/edit/index.vue
+++ b/frontend/src/pages/audits/edit/findings/edit/index.vue
@@ -121,31 +121,25 @@
                             class="col-md-12 basic-editor q-pt-none"
                             :class="{'highlighted-border': fieldHighlighted == 'descriptionField' && commentMode}"
                             borderless
+                            label-slot
                             stack-label
                                 :rules="($settings.report.public.requiredFields.findingDescription) ? [val => !!finding.description || $t('fieldIsRequired')] : ['']"
                                 lazy-rules="ondemand"
                                 >
                                 <template v-slot="control">
-                                    <div class="full-width">
-                                        <div id="descriptionField" class="row full-width no-wrap items-center q-mb-sm">
-                                            <div class="col">
-                                                {{$t('description')}} <span v-if="$settings.report.public.requiredFields.findingDescription" class="text-red">*</span>
-                                            </div>
-                                            <div class="col-auto">
-                                                <q-btn
-                                                class="all-pointer-events"
-                                                size="sm"
-                                                dense
-                                                outline
-                                                no-caps
-                                                color="secondary"
-                                                :loading="isAiFieldLoading('description')"
-                                                :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('description')"
-                                                label="AI Generate"
-                                                @click.stop="generateFieldDraftAI('description')"
-                                                />
-                                            </div>
-                                        </div>
+                                    <div class="finding-editor-wrap">
+                                        <q-btn
+                                        v-if="canGenerateAi('description')"
+                                        class="finding-ai-btn all-pointer-events"
+                                        size="sm"
+                                        unelevated
+                                        no-caps
+                                        color="secondary"
+                                        :loading="isAiFieldLoading('description')"
+                                        :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('description')"
+                                        label="AI"
+                                        @click.stop="generateFieldDraftAI('description')"
+                                        />
                                         <basic-editor
                                         ref="basiceditor_description"
                                         noSync
@@ -158,6 +152,11 @@
                                         />
                                     </div>
                                 </template>
+                                <template v-slot:label>
+                                    <div id="descriptionField">
+                                        {{$t('description')}} <span v-if="$settings.report.public.requiredFields.findingDescription" class="text-red">*</span>
+                                    </div>
+                                </template>
                             </q-field>
                             <q-field
                             ref="observationField"
@@ -165,30 +164,25 @@
                             class="col-md-12 basic-editor q-pt-none"
                             :class="{'highlighted-border': fieldHighlighted == 'observationField' && commentMode}"
                             borderless
+                            label-slot
                             stack-label
                             :rules="($settings.report.public.requiredFields.findingObservation) ? [val => !!finding.observation || $t('fieldIsRequired')] : ['']"
                             lazy-rules="ondemand"
                             >
                                 <template v-slot="control">
-                                    <div class="full-width">
-                                        <div id="observationField" class="row full-width no-wrap items-center q-mb-sm">
-                                            <div class="col">
-                                                {{$t('observation')}} <span v-if="$settings.report.public.requiredFields.findingObservation" class="text-red">*</span>
-                                            </div>
-                                            <div class="col-auto">
-                                                <q-btn
-                                                size="sm"
-                                                dense
-                                                outline
-                                                no-caps
-                                                color="secondary"
-                                                :loading="isAiFieldLoading('observation')"
-                                                :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('observation')"
-                                                label="AI Generate"
-                                                @click.stop="generateFieldDraftAI('observation')"
-                                                />
-                                            </div>
-                                        </div>
+                                    <div class="finding-editor-wrap">
+                                        <q-btn
+                                        v-if="canGenerateAi('observation')"
+                                        class="finding-ai-btn all-pointer-events"
+                                        size="sm"
+                                        unelevated
+                                        no-caps
+                                        color="secondary"
+                                        :loading="isAiFieldLoading('observation')"
+                                        :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('observation')"
+                                        label="AI"
+                                        @click.stop="generateFieldDraftAI('observation')"
+                                        />
                                         <basic-editor
                                         ref="basiceditor_observation"
                                         noSync
@@ -201,37 +195,40 @@
                                         />
                                     </div>
                                 </template>
+                                <template v-slot:label>
+                                    <div id="observationField">
+                                        {{$t('observation')}} <span v-if="$settings.report.public.requiredFields.findingObservation" class="text-red">*</span>
+                                    </div>
+                                </template>
                             </q-field>
-                            <div class="col-12 row items-center justify-between q-mt-sm q-mb-sm">
-                                <div>
-                                    {{$t('references')}}
-                                </div>
-                                <q-btn
-                                size="sm"
-                                dense
-                                outline
-                                no-caps
-                                color="secondary"
-                                :loading="isAiFieldLoading('references')"
-                                :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('references')"
-                                label="AI Generate"
-                                @click.stop="generateFieldDraftAI('references')"
-                                />
-                            </div>
                             <q-field 
                             class="col-12 q-pt-none" 
                             bg-color="transparent" 
                             borderless 
                             :class="{'highlighted-border': fieldHighlighted == 'referencesField' && commentMode}"
                             >
-                                <textarea-array
-                                ref="referencesField"
-                                id="referencesField"
-                                class="col-12 q-pt-none"
-                                :label="$t('references')+' '+$t('one_per_line')"
-                                v-model="finding.references"
-                                :rules="($settings.report.public.requiredFields.findingReferences) ? [val => !!val || $t('fieldIsRequired')] : ['']"
-                                :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT" />
+                                <div class="finding-editor-wrap">
+                                    <q-btn
+                                    v-if="canGenerateAi('references')"
+                                    class="finding-ai-btn all-pointer-events"
+                                    size="sm"
+                                    unelevated
+                                    no-caps
+                                    color="secondary"
+                                    :loading="isAiFieldLoading('references')"
+                                    :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('references')"
+                                    label="AI"
+                                    @click.stop="generateFieldDraftAI('references')"
+                                    />
+                                    <textarea-array
+                                    ref="referencesField"
+                                    id="referencesField"
+                                    class="col-12 q-pt-none"
+                                    :label="$t('references')+' '+$t('one_per_line')"
+                                    v-model="finding.references"
+                                    :rules="($settings.report.public.requiredFields.findingReferences) ? [val => !!val || $t('fieldIsRequired')] : ['']"
+                                    :readonly="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT" />
+                                </div>
                                 <q-badge v-if="commentMode && canCreateComment" color="deep-purple" floating class="cursor-pointer" @click="createComment('referencesField')">
                                     <q-icon name="add_comment" size="xs" />
                                 </q-badge>
@@ -256,6 +253,10 @@
                             :fieldHighlighted="fieldHighlighted"
                             :createComment="createComment"
                             :canCreateComment="canCreateComment"
+                            :aiEnabled="aiEnabled"
+                            :canGenerateAiForField="canGenerateAi"
+                            :isAiGeneratingField="isAiFieldLoading"
+                            :generateAiForField="generateCustomFieldDraftAI"
                             />
                         </q-expansion-item>
                     </q-card>
@@ -275,16 +276,30 @@
                             lazy-rules="ondemand"
                             >
                                 <template v-slot="control">
-                                    <basic-editor
-                                    ref="basiceditor_poc"
-                                    noSync
-                                    v-model="finding.poc"
-                                    :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
-                                    fieldName="pocField"
-                                    :commentMode="commentMode && canCreateComment"
-                                    :focusedComment="focusedComment"
-                                    :commentIdList="commentIdList"
-                                    />
+                                    <div class="finding-editor-wrap">
+                                        <q-btn
+                                        v-if="canGenerateAi('poc')"
+                                        class="finding-ai-btn all-pointer-events"
+                                        size="sm"
+                                        unelevated
+                                        no-caps
+                                        color="secondary"
+                                        :loading="isAiFieldLoading('poc')"
+                                        :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('poc')"
+                                        label="AI"
+                                        @click.stop="generateFieldDraftAI('poc')"
+                                        />
+                                        <basic-editor
+                                        ref="basiceditor_poc"
+                                        noSync
+                                        v-model="finding.poc"
+                                        :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
+                                        fieldName="pocField"
+                                        :commentMode="commentMode && canCreateComment"
+                                        :focusedComment="focusedComment"
+                                        :commentIdList="commentIdList"
+                                        />
+                                    </div>
                                 </template>
                                 <template v-slot:label>
                                     <div id="pocField">
@@ -417,30 +432,25 @@
                                 class="col-md-12 basic-editor"
                                 :class="{'highlighted-border': fieldHighlighted == 'remediationField' && commentMode}"
                                 borderless
+                                label-slot
                                 stack-label
                                 :rules="($settings.report.public.requiredFields.findingRemediation) ? [val => !!finding.remediation || $t('fieldIsRequired')] : ['']"
                                 lazy-rules="ondemand"
                                 >
                                     <template v-slot="control">
-                                        <div class="full-width">
-                                            <div id="remediationField" class="row full-width no-wrap items-center q-mb-sm">
-                                                <div class="col">
-                                                    {{$t('remediation')}} <span v-if="$settings.report.public.requiredFields.findingRemediation" class="text-red">*</span>
-                                                </div>
-                                                <div class="col-auto">
-                                                    <q-btn
-                                                    size="sm"
-                                                    dense
-                                                    outline
-                                                    no-caps
-                                                    color="secondary"
-                                                    :loading="isAiFieldLoading('remediation')"
-                                                    :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('remediation')"
-                                                    label="AI Generate"
-                                                    @click.stop="generateFieldDraftAI('remediation')"
-                                                    />
-                                                </div>
-                                            </div>
+                                        <div class="finding-editor-wrap">
+                                            <q-btn
+                                            v-if="canGenerateAi('remediation')"
+                                            class="finding-ai-btn all-pointer-events"
+                                            size="sm"
+                                            unelevated
+                                            no-caps
+                                            color="secondary"
+                                            :loading="isAiFieldLoading('remediation')"
+                                            :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('remediation')"
+                                            label="AI"
+                                            @click.stop="generateFieldDraftAI('remediation')"
+                                            />
                                             <basic-editor
                                             ref="basiceditor_remediation"
                                             noSync
@@ -451,6 +461,11 @@
                                             :focusedComment="focusedComment"
                                             :commentIdList="commentIdList"
                                             />
+                                        </div>
+                                    </template>
+                                    <template v-slot:label>
+                                        <div id="remediationField">
+                                            {{$t('remediation')}} <span v-if="$settings.report.public.requiredFields.findingRemediation" class="text-red">*</span>
                                         </div>
                                     </template>
                                 </q-field>
@@ -770,5 +785,17 @@
 
 .content-retest {
     margin-top: 50px;
+}
+
+.finding-editor-wrap {
+    position: relative;
+    width: 100%;
+}
+
+.finding-ai-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 5;
 }
 </style>

--- a/frontend/src/pages/audits/edit/findings/edit/index.vue
+++ b/frontend/src/pages/audits/edit/findings/edit/index.vue
@@ -120,27 +120,42 @@
                             for="descriptionField"
                             class="col-md-12 basic-editor q-pt-none"
                             :class="{'highlighted-border': fieldHighlighted == 'descriptionField' && commentMode}"
-                            label-slot
                             borderless
                             stack-label
-                            :rules="($settings.report.public.requiredFields.findingDescription) ? [val => !!finding.description || $t('fieldIsRequired')] : ['']"
-                            lazy-rules="ondemand"
-                            >
+                                :rules="($settings.report.public.requiredFields.findingDescription) ? [val => !!finding.description || $t('fieldIsRequired')] : ['']"
+                                lazy-rules="ondemand"
+                                >
                                 <template v-slot="control">
-                                    <basic-editor
-                                    ref="basiceditor_description"
-                                    noSync
-                                    v-model="finding.description"
-                                    :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
-                                    fieldName="descriptionField"
-                                    :commentMode="commentMode && canCreateComment"
-                                    :focusedComment="focusedComment"
-                                    :commentIdList="commentIdList"
-                                    />
-                                </template>
-                                <template v-slot:label>
-                                    <div id="descriptionField">
-                                        {{$t('description')}} <span v-if="$settings.report.public.requiredFields.findingDescription" class="text-red">*</span>
+                                    <div class="full-width">
+                                        <div id="descriptionField" class="row full-width no-wrap items-center q-mb-sm">
+                                            <div class="col">
+                                                {{$t('description')}} <span v-if="$settings.report.public.requiredFields.findingDescription" class="text-red">*</span>
+                                            </div>
+                                            <div class="col-auto">
+                                                <q-btn
+                                                class="all-pointer-events"
+                                                size="sm"
+                                                dense
+                                                outline
+                                                no-caps
+                                                color="secondary"
+                                                :loading="isAiFieldLoading('description')"
+                                                :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('description')"
+                                                label="AI Generate"
+                                                @click.stop="generateFieldDraftAI('description')"
+                                                />
+                                            </div>
+                                        </div>
+                                        <basic-editor
+                                        ref="basiceditor_description"
+                                        noSync
+                                        v-model="finding.description"
+                                        :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
+                                        fieldName="descriptionField"
+                                        :commentMode="commentMode && canCreateComment"
+                                        :focusedComment="focusedComment"
+                                        :commentIdList="commentIdList"
+                                        />
                                     </div>
                                 </template>
                             </q-field>
@@ -150,29 +165,59 @@
                             class="col-md-12 basic-editor q-pt-none"
                             :class="{'highlighted-border': fieldHighlighted == 'observationField' && commentMode}"
                             borderless
-                            label-slot
                             stack-label
                             :rules="($settings.report.public.requiredFields.findingObservation) ? [val => !!finding.observation || $t('fieldIsRequired')] : ['']"
                             lazy-rules="ondemand"
                             >
                                 <template v-slot="control">
-                                    <basic-editor
-                                    ref="basiceditor_observation"
-                                    noSync
-                                    v-model="finding.observation"
-                                    :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
-                                    fieldName="observationField"
-                                    :commentMode="commentMode && canCreateComment"
-                                    :focusedComment="focusedComment"
-                                    :commentIdList="commentIdList"
-                                    />
-                                </template>
-                                <template v-slot:label>
-                                    <div id="observationField">
-                                        {{$t('observation')}} <span v-if="$settings.report.public.requiredFields.findingObservation" class="text-red">*</span>
+                                    <div class="full-width">
+                                        <div id="observationField" class="row full-width no-wrap items-center q-mb-sm">
+                                            <div class="col">
+                                                {{$t('observation')}} <span v-if="$settings.report.public.requiredFields.findingObservation" class="text-red">*</span>
+                                            </div>
+                                            <div class="col-auto">
+                                                <q-btn
+                                                size="sm"
+                                                dense
+                                                outline
+                                                no-caps
+                                                color="secondary"
+                                                :loading="isAiFieldLoading('observation')"
+                                                :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('observation')"
+                                                label="AI Generate"
+                                                @click.stop="generateFieldDraftAI('observation')"
+                                                />
+                                            </div>
+                                        </div>
+                                        <basic-editor
+                                        ref="basiceditor_observation"
+                                        noSync
+                                        v-model="finding.observation"
+                                        :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
+                                        fieldName="observationField"
+                                        :commentMode="commentMode && canCreateComment"
+                                        :focusedComment="focusedComment"
+                                        :commentIdList="commentIdList"
+                                        />
                                     </div>
                                 </template>
                             </q-field>
+                            <div class="col-12 row items-center justify-between q-mt-sm q-mb-sm">
+                                <div>
+                                    {{$t('references')}}
+                                </div>
+                                <q-btn
+                                size="sm"
+                                dense
+                                outline
+                                no-caps
+                                color="secondary"
+                                :loading="isAiFieldLoading('references')"
+                                :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('references')"
+                                label="AI Generate"
+                                @click.stop="generateFieldDraftAI('references')"
+                                />
+                            </div>
                             <q-field 
                             class="col-12 q-pt-none" 
                             bg-color="transparent" 
@@ -372,25 +417,41 @@
                                 class="col-md-12 basic-editor"
                                 :class="{'highlighted-border': fieldHighlighted == 'remediationField' && commentMode}"
                                 borderless
-                                label-slot
                                 stack-label
                                 :rules="($settings.report.public.requiredFields.findingRemediation) ? [val => !!finding.remediation || $t('fieldIsRequired')] : ['']"
                                 lazy-rules="ondemand"
                                 >
                                     <template v-slot="control">
-                                        <basic-editor
-                                        ref="basiceditor_remediation"
-                                        noSync
-                                        v-model="finding.remediation"
-                                        :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
-                                        fieldName="remediationField"
-                                        :commentMode="commentMode && canCreateComment"
-                                        :focusedComment="focusedComment"
-                                        :commentIdList="commentIdList"
-                                        />
-                                    </template>
-                                    <template v-slot:label>
-                                        {{$t('remediation')}} <span v-if="$settings.report.public.requiredFields.findingRemediation" class="text-red">*</span>
+                                        <div class="full-width">
+                                            <div id="remediationField" class="row full-width no-wrap items-center q-mb-sm">
+                                                <div class="col">
+                                                    {{$t('remediation')}} <span v-if="$settings.report.public.requiredFields.findingRemediation" class="text-red">*</span>
+                                                </div>
+                                                <div class="col-auto">
+                                                    <q-btn
+                                                    size="sm"
+                                                    dense
+                                                    outline
+                                                    no-caps
+                                                    color="secondary"
+                                                    :loading="isAiFieldLoading('remediation')"
+                                                    :disable="frontEndAuditState !== AUDIT_VIEW_STATE.EDIT || isAiFieldLoading('remediation')"
+                                                    label="AI Generate"
+                                                    @click.stop="generateFieldDraftAI('remediation')"
+                                                    />
+                                                </div>
+                                            </div>
+                                            <basic-editor
+                                            ref="basiceditor_remediation"
+                                            noSync
+                                            v-model="finding.remediation"
+                                            :editable="frontEndAuditState === AUDIT_VIEW_STATE.EDIT"
+                                            fieldName="remediationField"
+                                            :commentMode="commentMode && canCreateComment"
+                                            :focusedComment="focusedComment"
+                                            :commentIdList="commentIdList"
+                                            />
+                                        </div>
                                     </template>
                                 </q-field>
                             </q-card-section>

--- a/frontend/src/pages/audits/edit/sections/index.vue
+++ b/frontend/src/pages/audits/edit/sections/index.vue
@@ -44,6 +44,10 @@
         :fieldHighlighted="fieldHighlighted"
         :createComment="createComment"
         :canCreateComment="canCreateComment"
+        :aiEnabled="aiEnabled"
+        :canGenerateAiForField="canGenerateAi"
+        :isAiGeneratingField="isAiFieldLoading"
+        :generateAiForField="generateCustomFieldDraftAI"
         />
     </q-card>
     <q-card v-if="commentMode" class="col-3 bg-grey-11 sidebar-comments" style="margin-top:2px">

--- a/frontend/src/pages/audits/edit/sections/sections.js
+++ b/frontend/src/pages/audits/edit/sections/sections.js
@@ -7,6 +7,7 @@ import CommentsList from 'components/comments-list';
 
 import AuditService from '@/services/audit';
 import DataService from '@/services/data';
+import AiService from '@/services/ai';
 import { useUserStore } from 'src/stores/user'
 import Utils from '@/services/utils';
 
@@ -28,6 +29,9 @@ export default {
             // List of CustomFields
             customFields: [],
             AUDIT_VIEW_STATE: Utils.AUDIT_VIEW_STATE,
+            aiEnabled: false,
+            aiPromptFieldKeys: [],
+            aiGeneratingFields: {},
             // Comments
             commentTemp: null,
             replyTemp: null,
@@ -65,6 +69,7 @@ export default {
         this.auditId = this.$route.params.auditId;
         this.sectionId = this.$route.params.sectionId;
         this.getSection();
+        this.getAiPromptsConfig();
 
         this.$socket.emit('menu', {menu: 'editSection', section: this.sectionId, room: this.auditId});
 
@@ -198,6 +203,143 @@ export default {
             .catch((err) => {
                 console.log(err)
             })
+        },
+
+        getAiPromptsConfig: function() {
+            DataService.getAiPrompts()
+            .then((data) => {
+                const payload = data.data.datas || {}
+                this.aiEnabled = payload.aiEnabled !== false
+                this.aiPromptFieldKeys = (payload.promptMappings || [])
+                .filter((mapping) => String(mapping.entityType || '') === 'section' && mapping.enabled !== false)
+                .map((mapping) => String(mapping.fieldKey || ''))
+            })
+            .catch(() => {
+                this.aiEnabled = false
+                this.aiPromptFieldKeys = []
+            })
+        },
+
+        getCustomFieldAiKey: function(customFieldId) {
+            return `custom-field:${customFieldId}`
+        },
+
+        canGenerateAi: function(fieldKey) {
+            return this.aiEnabled && this.aiPromptFieldKeys.includes(fieldKey)
+        },
+
+        isAiFieldLoading: function(fieldKey) {
+            return !!this.aiGeneratingFields[fieldKey]
+        },
+
+        generateCustomFieldDraftAI: async function(customField) {
+            const fieldKey = this.getCustomFieldAiKey(customField?.customField?._id)
+            if (!fieldKey || !this.canGenerateAi(fieldKey))
+                return
+
+            if (this.frontEndAuditState !== this.AUDIT_VIEW_STATE.EDIT || this.isAiFieldLoading(fieldKey))
+                return
+
+            Utils.syncEditors(this.$refs)
+            this.aiGeneratingFields[fieldKey] = true
+
+            try {
+                const customFieldContext = {}
+                if (this.section.customFields && this.section.customFields.length > 0) {
+                    this.section.customFields.forEach((entry) => {
+                        if (entry?.customField?.label)
+                            customFieldContext[entry.customField.label] = entry.text
+                    })
+                }
+
+                const response = await AiService.generateFieldDraft({
+                    entityType: 'section',
+                    field: fieldKey,
+                    locale: this.auditParent.language,
+                    context: {
+                        sectionField: this.section.field || '',
+                        sectionName: this.section.name || '',
+                        sectionText: this.section.text || '',
+                        customFieldLabel: customField?.customField?.label || '',
+                        customFieldValue: customField?.text || '',
+                        customFields: customFieldContext
+                    }
+                })
+
+                const rawDraft = response.data?.datas?.draft || ''
+                const outputType = response.data?.datas?.outputType || 'html'
+                const providerUsed = response.data?.datas?.provider || 'default provider'
+                let normalizedDraft = null
+
+                if (outputType === 'array') {
+                    const entries = Array.isArray(rawDraft)
+                        ? rawDraft
+                        : String(rawDraft).split('\n')
+
+                    normalizedDraft = entries
+                    .map((entry) => String(entry || '').trim())
+                    .filter(Boolean)
+
+                    if (normalizedDraft.length === 0)
+                        throw new Error('AI draft is empty')
+
+                    const preview = normalizedDraft
+                    .map((line) => line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'))
+                    .join('<br/>')
+
+                    Dialog.create({
+                        title: `AI Draft - ${customField?.customField?.label || fieldKey} (${providerUsed})`,
+                        html: true,
+                        message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${preview}</div><p class="q-mt-md">Apply this draft to the field?</p>`,
+                        ok: {label: 'Apply', color: 'primary'},
+                        cancel: {label: $t('btn.cancel'), color: 'white'}
+                    })
+                    .onOk(() => {
+                        customField.text = normalizedDraft
+                        Notify.create({
+                            message: `AI draft applied from ${providerUsed} (not saved yet)`,
+                            color: 'positive',
+                            textColor: 'white',
+                            position: 'top-right'
+                        })
+                    })
+                    return
+                }
+
+                normalizedDraft = String(rawDraft || '').trim()
+                if (!normalizedDraft)
+                    throw new Error('AI draft is empty')
+
+                const preview = (outputType === 'html') ?
+                    Utils.htmlEncode(normalizedDraft) :
+                    normalizedDraft.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+                Dialog.create({
+                    title: `AI Draft - ${customField?.customField?.label || fieldKey} (${providerUsed})`,
+                    html: true,
+                    message: `<div style="max-height:40vh;overflow:auto;border:1px solid #d7d7d7;padding:8px;">${preview}</div><p class="q-mt-md">Apply this draft to the field?</p>`,
+                    ok: {label: 'Apply', color: 'primary'},
+                    cancel: {label: $t('btn.cancel'), color: 'white'}
+                })
+                .onOk(() => {
+                    customField.text = (outputType === 'html') ? Utils.htmlEncode(normalizedDraft) : normalizedDraft
+                    Notify.create({
+                        message: `AI draft applied from ${providerUsed} (not saved yet)`,
+                        color: 'positive',
+                        textColor: 'white',
+                        position: 'top-right'
+                    })
+                })
+            } catch (err) {
+                Notify.create({
+                    message: err.response?.data?.datas || err.message || 'Unable to generate AI draft',
+                    color: 'negative',
+                    textColor: 'white',
+                    position: 'top-right'
+                })
+            } finally {
+                this.aiGeneratingFields[fieldKey] = false
+            }
         },
 
 

--- a/frontend/src/pages/data/ai-prompts/ai-prompts.js
+++ b/frontend/src/pages/data/ai-prompts/ai-prompts.js
@@ -1,0 +1,193 @@
+import { Notify } from 'quasar'
+import DataService from '@/services/data'
+import { useUserStore } from '@/stores/user'
+
+const userStore = useUserStore()
+
+const defaultPrompts = () => ({
+    description: '',
+    observation: '',
+    remediation: '',
+    references: ''
+})
+
+export default {
+    data: () => {
+        return {
+            loading: true,
+            saving: false,
+            canEdit: userStore.isAllowed('settings:update'),
+            defaultProvider: 'mock',
+            openaiApiKey: '',
+            showOpenAIApiKey: false,
+            hasOpenAIApiKey: false,
+            clearOpenAIApiKey: false,
+            anthropicApiKey: '',
+            showAnthropicApiKey: false,
+            hasAnthropicApiKey: false,
+            clearAnthropicApiKey: false,
+            deepseekApiKey: '',
+            showDeepseekApiKey: false,
+            hasDeepseekApiKey: false,
+            clearDeepseekApiKey: false,
+            ollamaApiKey: '',
+            showOllamaApiKey: false,
+            hasOllamaApiKey: false,
+            clearOllamaApiKey: false,
+            ollamaBaseUrl: 'http://localhost:11434/v1',
+            ollamaModel: 'llama3.1',
+            providerOptions: [
+                {label: 'Mock (Built-in)', value: 'mock'},
+                {label: 'OpenAI', value: 'openai'},
+                {label: 'Anthropic', value: 'anthropic'},
+                {label: 'DeepSeek', value: 'deepseek'},
+                {label: 'Ollama', value: 'ollama'}
+            ],
+            prompts: defaultPrompts(),
+            promptsOrig: {
+                defaultProvider: 'mock',
+                prompts: defaultPrompts(),
+                ollamaBaseUrl: 'http://localhost:11434/v1',
+                ollamaModel: 'llama3.1'
+            }
+        }
+    },
+
+    mounted: function() {
+        this.getAiPrompts()
+    },
+
+    computed: {
+        hasChanges: function() {
+            return JSON.stringify({
+                defaultProvider: this.defaultProvider,
+                prompts: this.prompts,
+                ollamaBaseUrl: this.ollamaBaseUrl,
+                ollamaModel: this.ollamaModel
+            }) !== JSON.stringify({
+                defaultProvider: this.promptsOrig.defaultProvider || 'mock',
+                prompts: this.promptsOrig.prompts || defaultPrompts(),
+                ollamaBaseUrl: this.promptsOrig.ollamaBaseUrl || 'http://localhost:11434/v1',
+                ollamaModel: this.promptsOrig.ollamaModel || 'llama3.1'
+            }) ||
+            Boolean(this.openaiApiKey.trim()) || this.clearOpenAIApiKey ||
+            Boolean(this.anthropicApiKey.trim()) || this.clearAnthropicApiKey ||
+            Boolean(this.deepseekApiKey.trim()) || this.clearDeepseekApiKey ||
+            Boolean(this.ollamaApiKey.trim()) || this.clearOllamaApiKey
+        }
+    },
+
+    methods: {
+        getAiPrompts: function() {
+            this.loading = true
+            DataService.getAiPrompts()
+            .then((data) => {
+                this.prompts = {...defaultPrompts(), ...(data.data.datas.prompts || {})}
+                this.defaultProvider = data.data.datas.defaultProvider || 'mock'
+                this.hasOpenAIApiKey = !!data.data.datas.hasOpenAIApiKey
+                this.clearOpenAIApiKey = false
+                this.openaiApiKey = ''
+                this.hasAnthropicApiKey = !!data.data.datas.hasAnthropicApiKey
+                this.clearAnthropicApiKey = false
+                this.anthropicApiKey = ''
+                this.hasDeepseekApiKey = !!data.data.datas.hasDeepseekApiKey
+                this.clearDeepseekApiKey = false
+                this.deepseekApiKey = ''
+                this.hasOllamaApiKey = !!data.data.datas.hasOllamaApiKey
+                this.clearOllamaApiKey = false
+                this.ollamaApiKey = ''
+                this.ollamaBaseUrl = data.data.datas.ollamaBaseUrl || 'http://localhost:11434/v1'
+                this.ollamaModel = data.data.datas.ollamaModel || 'llama3.1'
+                this.promptsOrig = {
+                    defaultProvider: this.defaultProvider,
+                    prompts: {...this.prompts},
+                    ollamaBaseUrl: this.ollamaBaseUrl,
+                    ollamaModel: this.ollamaModel
+                }
+            })
+            .catch((err) => {
+                Notify.create({
+                    message: err.response?.data?.datas || 'Failed to load AI prompts',
+                    color: 'negative',
+                    textColor: 'white',
+                    position: 'top-right'
+                })
+            })
+            .finally(() => {
+                this.loading = false
+            })
+        },
+
+        saveAiPrompts: function() {
+            if (!this.canEdit || this.saving)
+                return
+
+            this.saving = true
+            const payload = {
+                defaultProvider: this.defaultProvider,
+                prompts: this.prompts,
+                ollamaBaseUrl: this.ollamaBaseUrl,
+                ollamaModel: this.ollamaModel
+            }
+            if (this.clearOpenAIApiKey)
+                payload.openaiApiKey = ''
+            else if (this.openaiApiKey.trim())
+                payload.openaiApiKey = this.openaiApiKey.trim()
+            if (this.clearAnthropicApiKey)
+                payload.anthropicApiKey = ''
+            else if (this.anthropicApiKey.trim())
+                payload.anthropicApiKey = this.anthropicApiKey.trim()
+            if (this.clearDeepseekApiKey)
+                payload.deepseekApiKey = ''
+            else if (this.deepseekApiKey.trim())
+                payload.deepseekApiKey = this.deepseekApiKey.trim()
+            if (this.clearOllamaApiKey)
+                payload.ollamaApiKey = ''
+            else if (this.ollamaApiKey.trim())
+                payload.ollamaApiKey = this.ollamaApiKey.trim()
+
+            DataService.updateAiPrompts(payload)
+            .then((data) => {
+                this.prompts = {...defaultPrompts(), ...(data.data.datas.prompts || {})}
+                this.defaultProvider = data.data.datas.defaultProvider || 'mock'
+                this.hasOpenAIApiKey = !!data.data.datas.hasOpenAIApiKey
+                this.clearOpenAIApiKey = false
+                this.openaiApiKey = ''
+                this.hasAnthropicApiKey = !!data.data.datas.hasAnthropicApiKey
+                this.clearAnthropicApiKey = false
+                this.anthropicApiKey = ''
+                this.hasDeepseekApiKey = !!data.data.datas.hasDeepseekApiKey
+                this.clearDeepseekApiKey = false
+                this.deepseekApiKey = ''
+                this.hasOllamaApiKey = !!data.data.datas.hasOllamaApiKey
+                this.clearOllamaApiKey = false
+                this.ollamaApiKey = ''
+                this.ollamaBaseUrl = data.data.datas.ollamaBaseUrl || 'http://localhost:11434/v1'
+                this.ollamaModel = data.data.datas.ollamaModel || 'llama3.1'
+                this.promptsOrig = {
+                    defaultProvider: this.defaultProvider,
+                    prompts: {...this.prompts},
+                    ollamaBaseUrl: this.ollamaBaseUrl,
+                    ollamaModel: this.ollamaModel
+                }
+                Notify.create({
+                    message: 'AI prompts updated successfully',
+                    color: 'positive',
+                    textColor: 'white',
+                    position: 'top-right'
+                })
+            })
+            .catch((err) => {
+                Notify.create({
+                    message: err.response?.data?.datas || 'Failed to update AI prompts',
+                    color: 'negative',
+                    textColor: 'white',
+                    position: 'top-right'
+                })
+            })
+            .finally(() => {
+                this.saving = false
+            })
+        }
+    }
+}

--- a/frontend/src/pages/data/ai-prompts/ai-prompts.js
+++ b/frontend/src/pages/data/ai-prompts/ai-prompts.js
@@ -4,12 +4,29 @@ import { useUserStore } from '@/stores/user'
 
 const userStore = useUserStore()
 
-const defaultPrompts = () => ({
-    description: '',
-    observation: '',
-    remediation: '',
-    references: ''
-})
+const defaults = {
+    defaultProvider: 'openai',
+    openaiBaseUrl: 'https://api.openai.com/v1',
+    openaiModel: 'gpt-4.1-mini',
+    anthropicBaseUrl: 'https://api.anthropic.com/v1',
+    anthropicModel: 'claude-3-5-sonnet-latest',
+    anthropicVersion: '2023-06-01',
+    deepseekBaseUrl: 'https://api.deepseek.com/v1',
+    deepseekModel: 'deepseek-chat',
+    ollamaBaseUrl: 'http://localhost:11434/v1',
+    ollamaModel: 'llama3.1'
+}
+
+const serializePromptMappings = (mappings = []) => {
+    return mappings
+    .map((mapping) => ({
+        entityType: String(mapping.entityType || ''),
+        fieldKey: String(mapping.fieldKey || ''),
+        enabled: mapping.enabled !== false,
+        prompt: String(mapping.prompt || '')
+    }))
+    .sort((a, b) => `${a.entityType}:${a.fieldKey}`.localeCompare(`${b.entityType}:${b.fieldKey}`))
+}
 
 export default {
     data: () => {
@@ -17,38 +34,52 @@ export default {
             loading: true,
             saving: false,
             canEdit: userStore.isAllowed('settings:update'),
-            defaultProvider: 'mock',
+            aiEnabled: true,
+            defaultProvider: defaults.defaultProvider,
             openaiApiKey: '',
             showOpenAIApiKey: false,
             hasOpenAIApiKey: false,
             clearOpenAIApiKey: false,
+            openaiBaseUrl: defaults.openaiBaseUrl,
+            openaiModel: defaults.openaiModel,
             anthropicApiKey: '',
             showAnthropicApiKey: false,
             hasAnthropicApiKey: false,
             clearAnthropicApiKey: false,
+            anthropicBaseUrl: defaults.anthropicBaseUrl,
+            anthropicModel: defaults.anthropicModel,
+            anthropicVersion: defaults.anthropicVersion,
             deepseekApiKey: '',
             showDeepseekApiKey: false,
             hasDeepseekApiKey: false,
             clearDeepseekApiKey: false,
+            deepseekBaseUrl: defaults.deepseekBaseUrl,
+            deepseekModel: defaults.deepseekModel,
             ollamaApiKey: '',
             showOllamaApiKey: false,
             hasOllamaApiKey: false,
             clearOllamaApiKey: false,
-            ollamaBaseUrl: 'http://localhost:11434/v1',
-            ollamaModel: 'llama3.1',
+            ollamaBaseUrl: defaults.ollamaBaseUrl,
+            ollamaModel: defaults.ollamaModel,
             providerOptions: [
-                {label: 'Mock (Built-in)', value: 'mock'},
                 {label: 'OpenAI', value: 'openai'},
                 {label: 'Anthropic', value: 'anthropic'},
                 {label: 'DeepSeek', value: 'deepseek'},
                 {label: 'Ollama', value: 'ollama'}
             ],
-            prompts: defaultPrompts(),
+            promptMappings: [],
             promptsOrig: {
-                defaultProvider: 'mock',
-                prompts: defaultPrompts(),
-                ollamaBaseUrl: 'http://localhost:11434/v1',
-                ollamaModel: 'llama3.1'
+                defaultProvider: defaults.defaultProvider,
+                promptMappings: [],
+                openaiBaseUrl: defaults.openaiBaseUrl,
+                openaiModel: defaults.openaiModel,
+                anthropicBaseUrl: defaults.anthropicBaseUrl,
+                anthropicModel: defaults.anthropicModel,
+                anthropicVersion: defaults.anthropicVersion,
+                deepseekBaseUrl: defaults.deepseekBaseUrl,
+                deepseekModel: defaults.deepseekModel,
+                ollamaBaseUrl: defaults.ollamaBaseUrl,
+                ollamaModel: defaults.ollamaModel
             }
         }
     },
@@ -61,14 +92,28 @@ export default {
         hasChanges: function() {
             return JSON.stringify({
                 defaultProvider: this.defaultProvider,
-                prompts: this.prompts,
+                promptMappings: serializePromptMappings(this.promptMappings),
+                openaiBaseUrl: this.openaiBaseUrl,
+                openaiModel: this.openaiModel,
+                anthropicBaseUrl: this.anthropicBaseUrl,
+                anthropicModel: this.anthropicModel,
+                anthropicVersion: this.anthropicVersion,
+                deepseekBaseUrl: this.deepseekBaseUrl,
+                deepseekModel: this.deepseekModel,
                 ollamaBaseUrl: this.ollamaBaseUrl,
                 ollamaModel: this.ollamaModel
             }) !== JSON.stringify({
-                defaultProvider: this.promptsOrig.defaultProvider || 'mock',
-                prompts: this.promptsOrig.prompts || defaultPrompts(),
-                ollamaBaseUrl: this.promptsOrig.ollamaBaseUrl || 'http://localhost:11434/v1',
-                ollamaModel: this.promptsOrig.ollamaModel || 'llama3.1'
+                defaultProvider: this.promptsOrig.defaultProvider,
+                promptMappings: this.promptsOrig.promptMappings,
+                openaiBaseUrl: this.promptsOrig.openaiBaseUrl,
+                openaiModel: this.promptsOrig.openaiModel,
+                anthropicBaseUrl: this.promptsOrig.anthropicBaseUrl,
+                anthropicModel: this.promptsOrig.anthropicModel,
+                anthropicVersion: this.promptsOrig.anthropicVersion,
+                deepseekBaseUrl: this.promptsOrig.deepseekBaseUrl,
+                deepseekModel: this.promptsOrig.deepseekModel,
+                ollamaBaseUrl: this.promptsOrig.ollamaBaseUrl,
+                ollamaModel: this.promptsOrig.ollamaModel
             }) ||
             Boolean(this.openaiApiKey.trim()) || this.clearOpenAIApiKey ||
             Boolean(this.anthropicApiKey.trim()) || this.clearAnthropicApiKey ||
@@ -78,32 +123,61 @@ export default {
     },
 
     methods: {
+        applyPayload: function(payload) {
+            this.aiEnabled = payload.aiEnabled !== false
+            this.defaultProvider = payload.defaultProvider || defaults.defaultProvider
+            this.promptMappings = (payload.promptMappings || []).map((mapping) => ({
+                ...mapping,
+                entityType: String(mapping.entityType || ''),
+                enabled: mapping.enabled !== false,
+                prompt: String(mapping.prompt || '')
+            }))
+
+            this.hasOpenAIApiKey = !!payload.hasOpenAIApiKey
+            this.clearOpenAIApiKey = false
+            this.openaiApiKey = ''
+            this.openaiBaseUrl = payload.openaiBaseUrl || defaults.openaiBaseUrl
+            this.openaiModel = payload.openaiModel || defaults.openaiModel
+
+            this.hasAnthropicApiKey = !!payload.hasAnthropicApiKey
+            this.clearAnthropicApiKey = false
+            this.anthropicApiKey = ''
+            this.anthropicBaseUrl = payload.anthropicBaseUrl || defaults.anthropicBaseUrl
+            this.anthropicModel = payload.anthropicModel || defaults.anthropicModel
+            this.anthropicVersion = payload.anthropicVersion || defaults.anthropicVersion
+
+            this.hasDeepseekApiKey = !!payload.hasDeepseekApiKey
+            this.clearDeepseekApiKey = false
+            this.deepseekApiKey = ''
+            this.deepseekBaseUrl = payload.deepseekBaseUrl || defaults.deepseekBaseUrl
+            this.deepseekModel = payload.deepseekModel || defaults.deepseekModel
+
+            this.hasOllamaApiKey = !!payload.hasOllamaApiKey
+            this.clearOllamaApiKey = false
+            this.ollamaApiKey = ''
+            this.ollamaBaseUrl = payload.ollamaBaseUrl || defaults.ollamaBaseUrl
+            this.ollamaModel = payload.ollamaModel || defaults.ollamaModel
+
+            this.promptsOrig = {
+                defaultProvider: this.defaultProvider,
+                promptMappings: serializePromptMappings(this.promptMappings),
+                openaiBaseUrl: this.openaiBaseUrl,
+                openaiModel: this.openaiModel,
+                anthropicBaseUrl: this.anthropicBaseUrl,
+                anthropicModel: this.anthropicModel,
+                anthropicVersion: this.anthropicVersion,
+                deepseekBaseUrl: this.deepseekBaseUrl,
+                deepseekModel: this.deepseekModel,
+                ollamaBaseUrl: this.ollamaBaseUrl,
+                ollamaModel: this.ollamaModel
+            }
+        },
+
         getAiPrompts: function() {
             this.loading = true
             DataService.getAiPrompts()
             .then((data) => {
-                this.prompts = {...defaultPrompts(), ...(data.data.datas.prompts || {})}
-                this.defaultProvider = data.data.datas.defaultProvider || 'mock'
-                this.hasOpenAIApiKey = !!data.data.datas.hasOpenAIApiKey
-                this.clearOpenAIApiKey = false
-                this.openaiApiKey = ''
-                this.hasAnthropicApiKey = !!data.data.datas.hasAnthropicApiKey
-                this.clearAnthropicApiKey = false
-                this.anthropicApiKey = ''
-                this.hasDeepseekApiKey = !!data.data.datas.hasDeepseekApiKey
-                this.clearDeepseekApiKey = false
-                this.deepseekApiKey = ''
-                this.hasOllamaApiKey = !!data.data.datas.hasOllamaApiKey
-                this.clearOllamaApiKey = false
-                this.ollamaApiKey = ''
-                this.ollamaBaseUrl = data.data.datas.ollamaBaseUrl || 'http://localhost:11434/v1'
-                this.ollamaModel = data.data.datas.ollamaModel || 'llama3.1'
-                this.promptsOrig = {
-                    defaultProvider: this.defaultProvider,
-                    prompts: {...this.prompts},
-                    ollamaBaseUrl: this.ollamaBaseUrl,
-                    ollamaModel: this.ollamaModel
-                }
+                this.applyPayload(data.data.datas || {})
             })
             .catch((err) => {
                 Notify.create({
@@ -125,22 +199,38 @@ export default {
             this.saving = true
             const payload = {
                 defaultProvider: this.defaultProvider,
-                prompts: this.prompts,
+                promptMappings: this.promptMappings.map((mapping) => ({
+                    entityType: mapping.entityType,
+                    fieldKey: mapping.fieldKey,
+                    enabled: mapping.enabled !== false,
+                    prompt: mapping.prompt
+                })),
+                openaiBaseUrl: this.openaiBaseUrl,
+                openaiModel: this.openaiModel,
+                anthropicBaseUrl: this.anthropicBaseUrl,
+                anthropicModel: this.anthropicModel,
+                anthropicVersion: this.anthropicVersion,
+                deepseekBaseUrl: this.deepseekBaseUrl,
+                deepseekModel: this.deepseekModel,
                 ollamaBaseUrl: this.ollamaBaseUrl,
                 ollamaModel: this.ollamaModel
             }
+
             if (this.clearOpenAIApiKey)
                 payload.openaiApiKey = ''
             else if (this.openaiApiKey.trim())
                 payload.openaiApiKey = this.openaiApiKey.trim()
+
             if (this.clearAnthropicApiKey)
                 payload.anthropicApiKey = ''
             else if (this.anthropicApiKey.trim())
                 payload.anthropicApiKey = this.anthropicApiKey.trim()
+
             if (this.clearDeepseekApiKey)
                 payload.deepseekApiKey = ''
             else if (this.deepseekApiKey.trim())
                 payload.deepseekApiKey = this.deepseekApiKey.trim()
+
             if (this.clearOllamaApiKey)
                 payload.ollamaApiKey = ''
             else if (this.ollamaApiKey.trim())
@@ -148,28 +238,7 @@ export default {
 
             DataService.updateAiPrompts(payload)
             .then((data) => {
-                this.prompts = {...defaultPrompts(), ...(data.data.datas.prompts || {})}
-                this.defaultProvider = data.data.datas.defaultProvider || 'mock'
-                this.hasOpenAIApiKey = !!data.data.datas.hasOpenAIApiKey
-                this.clearOpenAIApiKey = false
-                this.openaiApiKey = ''
-                this.hasAnthropicApiKey = !!data.data.datas.hasAnthropicApiKey
-                this.clearAnthropicApiKey = false
-                this.anthropicApiKey = ''
-                this.hasDeepseekApiKey = !!data.data.datas.hasDeepseekApiKey
-                this.clearDeepseekApiKey = false
-                this.deepseekApiKey = ''
-                this.hasOllamaApiKey = !!data.data.datas.hasOllamaApiKey
-                this.clearOllamaApiKey = false
-                this.ollamaApiKey = ''
-                this.ollamaBaseUrl = data.data.datas.ollamaBaseUrl || 'http://localhost:11434/v1'
-                this.ollamaModel = data.data.datas.ollamaModel || 'llama3.1'
-                this.promptsOrig = {
-                    defaultProvider: this.defaultProvider,
-                    prompts: {...this.prompts},
-                    ollamaBaseUrl: this.ollamaBaseUrl,
-                    ollamaModel: this.ollamaModel
-                }
+                this.applyPayload(data.data.datas || {})
                 Notify.create({
                     message: 'AI prompts updated successfully',
                     color: 'positive',

--- a/frontend/src/pages/data/ai-prompts/index.vue
+++ b/frontend/src/pages/data/ai-prompts/index.vue
@@ -1,0 +1,203 @@
+<template>
+    <div class="row">
+        <div class="col-md-10 col-12 offset-md-1 q-mt-md">
+            <q-card>
+                <q-card-section class="bg-blue-grey-5 text-white">
+                    <div class="text-h6">AI Prompts</div>
+                </q-card-section>
+                <q-card-section v-if="loading">
+                    <q-spinner color="primary" size="2em" />
+                </q-card-section>
+                <template v-else>
+                    <q-card-section>
+                        <div class="text-grey-8">
+                            Configure generation prompts used by AI for finding fields.
+                            Placeholders supported: <code>{title}</code>, <code>{vulnType}</code>,
+                            <code>{description}</code>, <code>{observation}</code>, <code>{remediation}</code>, <code>{references}</code>.
+                        </div>
+                        <div v-if="!canEdit" class="text-orange q-mt-sm">
+                            Read-only: only admins can update prompts.
+                        </div>
+                    </q-card-section>
+
+                    <q-separator />
+
+                    <q-card-section>
+                        <q-select
+                        outlined
+                        emit-value
+                        map-options
+                        options-sanitize
+                        label="Default Provider"
+                        class="col-md-4 col-12"
+                        v-model="defaultProvider"
+                        :options="providerOptions"
+                        :readonly="!canEdit"
+                        />
+                    </q-card-section>
+
+                    <q-card-section v-if="canEdit && defaultProvider === 'openai'">
+                        <q-input
+                        v-if="!hasOpenAIApiKey"
+                        outlined
+                        :type="showOpenAIApiKey ? 'text' : 'password'"
+                        label="OpenAI API Key"
+                        v-model="openaiApiKey"
+                        :readonly="!canEdit"
+                        >
+                            <template v-slot:append>
+                                <q-icon
+                                :name="showOpenAIApiKey ? 'visibility_off' : 'visibility'"
+                                class="cursor-pointer"
+                                @click="showOpenAIApiKey = !showOpenAIApiKey"
+                                />
+                            </template>
+                        </q-input>
+                        <q-checkbox
+                        v-if="canEdit && hasOpenAIApiKey"
+                        class="q-mt-xs"
+                        v-model="clearOpenAIApiKey"
+                        label="Clear stored OpenAI API key"
+                        />
+                    </q-card-section>
+
+                    <q-card-section v-if="canEdit && defaultProvider === 'anthropic'">
+                        <q-input
+                        v-if="!hasAnthropicApiKey"
+                        outlined
+                        :type="showAnthropicApiKey ? 'text' : 'password'"
+                        label="Anthropic API Key"
+                        v-model="anthropicApiKey"
+                        :readonly="!canEdit"
+                        >
+                            <template v-slot:append>
+                                <q-icon
+                                :name="showAnthropicApiKey ? 'visibility_off' : 'visibility'"
+                                class="cursor-pointer"
+                                @click="showAnthropicApiKey = !showAnthropicApiKey"
+                                />
+                            </template>
+                        </q-input>
+                        <q-checkbox
+                        v-if="canEdit && hasAnthropicApiKey"
+                        class="q-mt-xs"
+                        v-model="clearAnthropicApiKey"
+                        label="Clear stored Anthropic API key"
+                        />
+                    </q-card-section>
+
+                    <q-card-section v-if="canEdit && defaultProvider === 'deepseek'">
+                        <q-input
+                        v-if="!hasDeepseekApiKey"
+                        outlined
+                        :type="showDeepseekApiKey ? 'text' : 'password'"
+                        label="DeepSeek API Key"
+                        v-model="deepseekApiKey"
+                        :readonly="!canEdit"
+                        >
+                            <template v-slot:append>
+                                <q-icon
+                                :name="showDeepseekApiKey ? 'visibility_off' : 'visibility'"
+                                class="cursor-pointer"
+                                @click="showDeepseekApiKey = !showDeepseekApiKey"
+                                />
+                            </template>
+                        </q-input>
+                        <q-checkbox
+                        v-if="canEdit && hasDeepseekApiKey"
+                        class="q-mt-xs"
+                        v-model="clearDeepseekApiKey"
+                        label="Clear stored DeepSeek API key"
+                        />
+                    </q-card-section>
+
+                    <q-card-section v-if="canEdit && defaultProvider === 'ollama'" class="q-gutter-md">
+                        <q-input
+                        outlined
+                        label="Ollama Base URL"
+                        v-model="ollamaBaseUrl"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        label="Ollama Model"
+                        v-model="ollamaModel"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        v-if="!hasOllamaApiKey"
+                        outlined
+                        :type="showOllamaApiKey ? 'text' : 'password'"
+                        label="Ollama API Key"
+                        v-model="ollamaApiKey"
+                        :readonly="!canEdit"
+                        >
+                            <template v-slot:append>
+                                <q-icon
+                                :name="showOllamaApiKey ? 'visibility_off' : 'visibility'"
+                                class="cursor-pointer"
+                                @click="showOllamaApiKey = !showOllamaApiKey"
+                                />
+                            </template>
+                        </q-input>
+                        <q-checkbox
+                        v-if="canEdit && hasOllamaApiKey"
+                        class="q-mt-xs"
+                        v-model="clearOllamaApiKey"
+                        label="Clear stored Ollama API key"
+                        />
+                    </q-card-section>
+
+                    <q-card-section class="q-gutter-md">
+                        <q-input
+                        outlined
+                        type="textarea"
+                        autogrow
+                        label="Description Prompt"
+                        v-model="prompts.description"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        type="textarea"
+                        autogrow
+                        label="Observation Prompt"
+                        v-model="prompts.observation"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        type="textarea"
+                        autogrow
+                        label="Remediation Prompt"
+                        v-model="prompts.remediation"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        type="textarea"
+                        autogrow
+                        label="References Prompt"
+                        v-model="prompts.references"
+                        :readonly="!canEdit"
+                        />
+                    </q-card-section>
+
+                    <q-card-actions align="right">
+                        <q-btn
+                        color="secondary"
+                        unelevated
+                        no-caps
+                        label="Save Prompts"
+                        :disable="!canEdit || !hasChanges"
+                        :loading="saving"
+                        @click="saveAiPrompts()"
+                        />
+                    </q-card-actions>
+                </template>
+            </q-card>
+        </div>
+    </div>
+</template>
+
+<script src="./ai-prompts.js"></script>

--- a/frontend/src/pages/data/ai-prompts/index.vue
+++ b/frontend/src/pages/data/ai-prompts/index.vue
@@ -5,15 +5,26 @@
                 <q-card-section class="bg-blue-grey-5 text-white">
                     <div class="text-h6">AI Prompts</div>
                 </q-card-section>
+
                 <q-card-section v-if="loading">
                     <q-spinner color="primary" size="2em" />
                 </q-card-section>
+
+                <template v-else-if="!aiEnabled">
+                    <q-card-section>
+                        <q-banner dense class="bg-orange-1 text-orange-10">
+                            AI integration is disabled in organization settings. Enable it from <b>Settings</b> to manage prompts.
+                        </q-banner>
+                    </q-card-section>
+                </template>
+
                 <template v-else>
                     <q-card-section>
                         <div class="text-grey-8">
-                            Configure generation prompts used by AI for finding fields.
+                            Configure generation prompts mapped to report fields.
                             Placeholders supported: <code>{title}</code>, <code>{vulnType}</code>,
-                            <code>{description}</code>, <code>{observation}</code>, <code>{remediation}</code>, <code>{references}</code>.
+                            <code>{description}</code>, <code>{observation}</code>, <code>{remediation}</code>,
+                            <code>{references}</code>, <code>{poc}</code>, <code>{customFieldLabel}</code>, <code>{customFieldValue}</code>.
                         </div>
                         <div v-if="!canEdit" class="text-orange q-mt-sm">
                             Read-only: only admins can update prompts.
@@ -36,7 +47,19 @@
                         />
                     </q-card-section>
 
-                    <q-card-section v-if="canEdit && defaultProvider === 'openai'">
+                    <q-card-section v-if="canEdit && defaultProvider === 'openai'" class="q-gutter-md">
+                        <q-input
+                        outlined
+                        label="OpenAI Base URL"
+                        v-model="openaiBaseUrl"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        label="OpenAI Model"
+                        v-model="openaiModel"
+                        :readonly="!canEdit"
+                        />
                         <q-input
                         v-if="!hasOpenAIApiKey"
                         outlined
@@ -61,7 +84,25 @@
                         />
                     </q-card-section>
 
-                    <q-card-section v-if="canEdit && defaultProvider === 'anthropic'">
+                    <q-card-section v-if="canEdit && defaultProvider === 'anthropic'" class="q-gutter-md">
+                        <q-input
+                        outlined
+                        label="Anthropic Base URL"
+                        v-model="anthropicBaseUrl"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        label="Anthropic Model"
+                        v-model="anthropicModel"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        label="Anthropic Version"
+                        v-model="anthropicVersion"
+                        :readonly="!canEdit"
+                        />
                         <q-input
                         v-if="!hasAnthropicApiKey"
                         outlined
@@ -86,7 +127,19 @@
                         />
                     </q-card-section>
 
-                    <q-card-section v-if="canEdit && defaultProvider === 'deepseek'">
+                    <q-card-section v-if="canEdit && defaultProvider === 'deepseek'" class="q-gutter-md">
+                        <q-input
+                        outlined
+                        label="DeepSeek Base URL"
+                        v-model="deepseekBaseUrl"
+                        :readonly="!canEdit"
+                        />
+                        <q-input
+                        outlined
+                        label="DeepSeek Model"
+                        v-model="deepseekModel"
+                        :readonly="!canEdit"
+                        />
                         <q-input
                         v-if="!hasDeepseekApiKey"
                         outlined
@@ -149,38 +202,38 @@
                     </q-card-section>
 
                     <q-card-section class="q-gutter-md">
-                        <q-input
-                        outlined
-                        type="textarea"
-                        autogrow
-                        label="Description Prompt"
-                        v-model="prompts.description"
-                        :readonly="!canEdit"
-                        />
-                        <q-input
-                        outlined
-                        type="textarea"
-                        autogrow
-                        label="Observation Prompt"
-                        v-model="prompts.observation"
-                        :readonly="!canEdit"
-                        />
-                        <q-input
-                        outlined
-                        type="textarea"
-                        autogrow
-                        label="Remediation Prompt"
-                        v-model="prompts.remediation"
-                        :readonly="!canEdit"
-                        />
-                        <q-input
-                        outlined
-                        type="textarea"
-                        autogrow
-                        label="References Prompt"
-                        v-model="prompts.references"
-                        :readonly="!canEdit"
-                        />
+                        <q-card
+                        v-for="mapping in promptMappings"
+                        :key="`${mapping.entityType}:${mapping.fieldKey}`"
+                        bordered
+                        flat
+                        class="q-pa-md"
+                        >
+                            <div class="row items-center q-col-gutter-md q-mb-sm">
+                                <div class="col">
+                                    <div class="text-subtitle2">{{ mapping.fieldLabel }}</div>
+                                    <div class="text-caption text-grey-7">
+                                        Entity: {{ mapping.entityType }} | Field key: {{ mapping.fieldKey }} | Output: {{ mapping.outputType }}
+                                    </div>
+                                </div>
+                                <div class="col-auto">
+                                    <q-toggle
+                                    v-model="mapping.enabled"
+                                    label="Enable AI"
+                                    :disable="!canEdit"
+                                    />
+                                </div>
+                            </div>
+                            <q-input
+                            outlined
+                            type="textarea"
+                            autogrow
+                            :label="`${mapping.fieldLabel} Prompt`"
+                            v-model="mapping.prompt"
+                            :readonly="!canEdit"
+                            :disable="!mapping.enabled"
+                            />
+                        </q-card>
                     </q-card-section>
 
                     <q-card-actions align="right">

--- a/frontend/src/pages/data/index.vue
+++ b/frontend/src/pages/data/index.vue
@@ -42,6 +42,12 @@
                 </q-item-section>
                 <q-item-section>{{$t('languageToolRules')}}</q-item-section>
             </q-item>
+            <q-item to='/data/ai-prompts'>
+                <q-item-section avatar>
+                    <q-icon name="fa fa-robot" />
+                </q-item-section>
+                <q-item-section>AI Prompts</q-item-section>
+            </q-item>
 
             <q-separator spaced />
 
@@ -64,4 +70,3 @@
 </template>
 
 <script></script>
-

--- a/frontend/src/pages/data/index.vue
+++ b/frontend/src/pages/data/index.vue
@@ -42,7 +42,7 @@
                 </q-item-section>
                 <q-item-section>{{$t('languageToolRules')}}</q-item-section>
             </q-item>
-            <q-item to='/data/ai-prompts'>
+            <q-item v-if="$settings.ai && $settings.ai.public && $settings.ai.public.enabled" to='/data/ai-prompts'>
                 <q-item-section avatar>
                     <q-icon name="fa fa-robot" />
                 </q-item-section>

--- a/frontend/src/pages/settings/index.vue
+++ b/frontend/src/pages/settings/index.vue
@@ -25,6 +25,29 @@
             <q-card v-if="userStore.isAllowed('settings:read')" class="q-my-lg">
                 <q-card-section class="q-py-none bg-blue-grey-5 text-white">
                     <q-item style="padding:0px;">
+                        <q-item-section class="col-11">
+                            <div class="text-h6">AI Integration</div>
+                        </q-item-section>
+                        <q-item-section class="col-md-1 items-center">
+                            <q-toggle
+                                color="primary"
+                                keep-color
+                                :disable="!canEdit"
+                                v-model="settings.ai.public.enabled"
+                            />
+                        </q-item-section>
+                    </q-item>
+                </q-card-section>
+                <q-card-section>
+                    <div class="text-grey-8">
+                        Disable to fully hide AI prompt configuration and AI generation buttons for all users.
+                    </div>
+                </q-card-section>
+            </q-card>
+
+            <q-card v-if="userStore.isAllowed('settings:read')" class="q-my-lg">
+                <q-card-section class="q-py-none bg-blue-grey-5 text-white">
+                    <q-item style="padding:0px;">
                         <q-item-section class="col-md-11">
                             <div class="text-h6">{{$t('reports')}}</div>
                         </q-item-section>

--- a/frontend/src/pages/settings/settings.js
+++ b/frontend/src/pages/settings/settings.js
@@ -139,6 +139,9 @@ export default {
             SettingsService.getSettings()
             .then((data) => {
                 this.settings = data.data.datas;
+                if (!this.settings.ai) this.settings.ai = {public: {enabled: true}, private: {}}
+                if (!this.settings.ai.public) this.settings.ai.public = {enabled: true}
+                if (typeof this.settings.ai.public.enabled !== 'boolean') this.settings.ai.public.enabled = true
                 this.settingsOrig = this.$_.cloneDeep(this.settings);
                 this.loading = false
             })

--- a/frontend/src/router/routes.js
+++ b/frontend/src/router/routes.js
@@ -21,6 +21,7 @@ export default [
       {path: 'templates', component: () => import('pages/data/templates')},
       {path: 'spellcheck', component: () => import('pages/data/spellcheck')},
       {path: 'languagetool-rules', component: () => import('pages/data/languagetool-rules')},
+      {path: 'ai-prompts', component: () => import('pages/data/ai-prompts')},
       {path: 'dump', component: () => import('pages/data/dump')},
       {path: 'custom', component: () => import('pages/data/custom')}
     ]},

--- a/frontend/src/services/ai.js
+++ b/frontend/src/services/ai.js
@@ -1,0 +1,7 @@
+import { api } from 'boot/axios'
+
+export default {
+  generateFieldDraft: function(params) {
+    return api.post('ai/generate', params)
+  },
+}

--- a/frontend/src/services/data.js
+++ b/frontend/src/services/data.js
@@ -103,5 +103,13 @@ export default {
 
     updateSections: function(sections) {
         return api.put(`data/sections`, sections)
+    },
+
+    getAiPrompts: function() {
+        return api.get('data/ai-prompts')
+    },
+
+    updateAiPrompts: function(payload) {
+        return api.put('data/ai-prompts', payload)
     }
 }


### PR DESCRIPTION
This adds AI-assisted report generation.

In `Data`, a new **AI Prompts** section was added to:
- choose the default AI provider (`mock`, `openai`, `anthropic`, `deepseek`, `ollama`)
- configure prompts for `description`, `observation`, `remediation`, and `references`
- manage provider credentials/config (admin-only, shown per selected provider)

In `Audits`, **AI Generate** buttons were added to findings fields so content is generated only when the user clicks the button (no automatic generation).  
Supported fields are:
- Description
- Observation
- References
- Remediation

Backend routes/settings were extended to store AI provider config and prompts, and to generate drafts using the selected provider.