### PR TITLE
Feature: statistics export

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "full-icu": "^1.5.0",
     "htmlparser2": "^10.0.0",
     "image-size": "^2.0.2",
+    "js-yaml": "4.1.1",
     "JSONStream": "^1.3.5",
     "jsonwebtoken": "^9.0.3",
     "highlight.js": "^11.11.1",

--- a/backend/src/models/audit.js
+++ b/backend/src/models/audit.js
@@ -1172,6 +1172,141 @@ AuditSchema.statics.getAuditsImages = (auditsIds = []) => {
     })
 }
 
+AuditSchema.statics.getFindingStatsByType = (isAdmin, userId, filters = {}) => {
+    return new Promise(async (resolve, reject) => {
+        var Settings = mongoose.model('Settings');
+        var settings = await Settings.getAll();
+
+        var pipeline = []
+
+        // Build match filter for access control
+        var matchFilter = {}
+        if (filters.companyId)
+            matchFilter.company = new mongoose.Types.ObjectId(filters.companyId)
+        if (filters.dateFrom || filters.dateTo) {
+            matchFilter.createdAt = {}
+            if (filters.dateFrom) matchFilter.createdAt.$gte = new Date(filters.dateFrom)
+            if (filters.dateTo) matchFilter.createdAt.$lte = new Date(filters.dateTo)
+        }
+        if (filters.auditType)
+            matchFilter.auditType = filters.auditType
+
+        // Apply base filters
+        if (Object.keys(matchFilter).length > 0)
+            pipeline.push({ $match: matchFilter })
+
+        // Apply access control filter if not admin
+        if (!isAdmin) {
+            pipeline.push({
+                $match: {
+                    $or: [
+                        { creator: new mongoose.Types.ObjectId(userId) },
+                        { collaborators: new mongoose.Types.ObjectId(userId) },
+                        { reviewers: new mongoose.Types.ObjectId(userId) }
+                    ]
+                }
+            })
+        }
+
+        // Count total audits before unwinding
+        var auditCountPipeline = [...pipeline]
+
+        // Unwind findings array
+        pipeline.push({ $unwind: { path: '$findings', preserveNullAndEmptyArrays: false } })
+
+        // Project fields needed for grouping and severity calculation
+        pipeline.push({
+            $project: {
+                vulnType: { $ifNull: ['$findings.vulnType', 'Uncategorized'] },
+                cvssv3: '$findings.cvssv3',
+                cvssv4: '$findings.cvssv4'
+            }
+        })
+
+        // Group by vulnType
+        pipeline.push({
+            $group: {
+                _id: '$vulnType',
+                count: { $sum: 1 },
+                findings: { $push: { cvssv3: '$cvssv3', cvssv4: '$cvssv4' } }
+            }
+        })
+
+        // Sort by count descending
+        pipeline.push({ $sort: { count: -1 } })
+
+        try {
+            // Get audit count
+            auditCountPipeline.push({ $count: 'total' })
+            var auditCountResult = await Audit.aggregate(auditCountPipeline)
+            var totalAudits = auditCountResult.length > 0 ? auditCountResult[0].total : 0
+
+            // Get findings grouped by type
+            var rows = await Audit.aggregate(pipeline)
+
+            // Calculate severity breakdown for each type
+            var totalFindings = 0
+            var statisticsByType = rows.map(row => {
+                totalFindings += row.count
+
+                var bySeverity = { critical: 0, high: 0, medium: 0, low: 0, none: 0 }
+
+                row.findings.forEach(finding => {
+                    var score = null
+
+                    // Prefer CVSS v4, fallback to v3
+                    if (settings.report.public.scoringMethods.CVSS4 && finding.cvssv4) {
+                        try {
+                            var cvssObj = new cvss.Cvss4P0(finding.cvssv4).createJsonSchema()
+                            score = cvssObj.baseScore
+                        } catch (e) { /* ignore invalid vectors */ }
+                    } else if (settings.report.public.scoringMethods.CVSS3 && finding.cvssv3) {
+                        try {
+                            var cvssObj = new cvss.Cvss3P1(finding.cvssv3).createJsonSchema()
+                            score = cvssObj.baseScore
+                        } catch (e) { /* ignore invalid vectors */ }
+                    }
+
+                    // Categorize by severity
+                    if (score === null || score === 0) {
+                        bySeverity.none++
+                    } else if (score >= 9.0) {
+                        bySeverity.critical++
+                    } else if (score >= 7.0) {
+                        bySeverity.high++
+                    } else if (score >= 4.0) {
+                        bySeverity.medium++
+                    } else {
+                        bySeverity.low++
+                    }
+                })
+
+                return {
+                    vulnType: row._id,
+                    count: row.count,
+                    bySeverity: bySeverity
+                }
+            })
+
+            // Calculate percentages
+            statisticsByType.forEach(stat => {
+                stat.percentage = totalFindings > 0
+                    ? Math.round((stat.count / totalFindings) * 10000) / 100
+                    : 0
+            })
+
+            resolve({
+                generatedAt: new Date().toISOString(),
+                totalFindings: totalFindings,
+                totalAudits: totalAudits,
+                statisticsByType: statisticsByType
+            })
+        } catch (err) {
+            reject(err)
+        }
+    })
+}
+
 AuditSchema.statics.backup = (path, auditsIds = []) => {
     return new Promise(async (resolve, reject) => {
         const fs = require('fs')

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -51,6 +51,49 @@ module.exports = function(app, io) {
         .catch(err => Response.Internal(res, err))
     });
 
+    // Get finding statistics by vulnerability type
+    app.get("/api/audits/stats/findings-by-type", acl.hasPermission('data:stats'), function(req, res) {
+        var YAML = require('js-yaml');
+        var format = req.query.format || 'json';
+        var filters = {};
+
+        // Optional filters
+        if (req.query.companyId) filters.companyId = req.query.companyId;
+        if (req.query.auditType) filters.auditType = req.query.auditType;
+        if (req.query.dateFrom) filters.dateFrom = req.query.dateFrom;
+        if (req.query.dateTo) filters.dateTo = req.query.dateTo;
+
+        Audit.getFindingStatsByType(
+            acl.isAllowed(req.decodedToken.role, 'audits:read-all'),
+            req.decodedToken.id,
+            filters
+        )
+        .then(stats => {
+            if (format === 'yaml') {
+                var yamlData = YAML.dump(stats);
+                res.set('Content-Type', 'application/yaml');
+                res.set('Content-Disposition', 'attachment; filename="finding-statistics.yml"');
+                res.send(yamlData);
+            } else if (format === 'csv') {
+                var lines = ['Vulnerability Type,Count,Percentage,Critical,High,Medium,Low,None'];
+                stats.statisticsByType.forEach(s => {
+                    lines.push(`"${s.vulnType}",${s.count},${s.percentage},${s.bySeverity.critical},${s.bySeverity.high},${s.bySeverity.medium},${s.bySeverity.low},${s.bySeverity.none}`);
+                });
+                lines.push('');
+                lines.push(`Total Findings,${stats.totalFindings}`);
+                lines.push(`Total Audits,${stats.totalAudits}`);
+                lines.push(`Generated At,${stats.generatedAt}`);
+                var csvData = lines.join('\n');
+                res.set('Content-Type', 'text/csv');
+                res.set('Content-Disposition', 'attachment; filename="finding-statistics.csv"');
+                res.send(csvData);
+            } else {
+                Response.Ok(res, stats);
+            }
+        })
+        .catch(err => Response.Internal(res, err))
+    });
+
     // Create audit (default or multi) with name, auditType, language provided
     // parentId can be set only if type is default
     app.post("/api/audits", acl.hasPermission('audits:create'), function(req, res) {

--- a/frontend/src/i18n/en-US/index.js
+++ b/frontend/src/i18n/en-US/index.js
@@ -126,6 +126,7 @@ export default {
         companyCreatedOk: 'Company created successfully',
         companyUpdatedOk: 'Company updated successfully',
         companyDeletedOk: 'Company deleted successfully',
+        downloadStatsFailed: 'Failed to download statistics',
         templateNotFound: 'Template Not Found',
         templateCreatedOk: 'Template created successfully',
         templateUpdatedOk: 'Template updated successfully',
@@ -684,6 +685,14 @@ export default {
     deleteAllVulnerabilities: 'Delete All Vulnerabilities',
     deleteAllVulnerabilitiesInfo: `Delete all existing vulnerabilities.<br />
     <strong>This action is definitive!!</strong>`,
+    findingStatistics: 'Finding Statistics by Vulnerability Type',
+    findingStatisticsInfo: `Download statistics showing the distribution of findings across all audits, grouped by vulnerability type.<br />
+    This includes counts, percentages, and CVSS severity breakdowns.`,
+    downloadStatistics: 'Download Statistics',
+    exportFormat: 'Format',
+    dateFrom: 'Date From',
+    dateTo: 'Date To',
+    noStatsPermission: 'You do not have permission to view finding statistics.',
     customSections: 'Custom Sections',
     listOfLanguages: 'List of Languages',
     editLanguages: 'Edit Languages',

--- a/frontend/src/pages/data/dump/dump.js
+++ b/frontend/src/pages/data/dump/dump.js
@@ -2,6 +2,8 @@ import { Dialog, Notify } from 'quasar'
 import YAML from 'js-yaml'
 
 import VulnerabilityService from '@/services/vulnerability'
+import AuditService from '@/services/audit'
+import CompanyService from '@/services/company'
 import { useUserStore } from 'src/stores/user'
 
 import { $t } from '@/boot/i18n'
@@ -13,11 +15,25 @@ export default {
         return {
             userStore: userStore,
             vulnerabilities: [],
+            // Finding statistics
+            statsFormat: 'json',
+            formatOptions: [
+                { label: 'JSON', value: 'json' },
+                { label: 'YAML', value: 'yaml' },
+                { label: 'CSV', value: 'csv' }
+            ],
+            companies: [],
+            selectedCompany: null,
+            dateFrom: '',
+            dateTo: '',
+            loadingStats: false
         }
     },
 
     mounted: function() {
-        
+        if (this.userStore.isAllowed('data:stats')) {
+            this.getCompanies();
+        }
     },
 
     methods: {
@@ -259,6 +275,58 @@ export default {
                     })
                 })
             })
+        },
+
+        getCompanies: function() {
+            CompanyService.getCompanies()
+            .then((data) => {
+                this.companies = data.data.datas;
+            })
+            .catch((err) => {
+                console.log('Could not load companies:', err);
+            });
+        },
+
+        downloadFindingStats: function() {
+            this.loadingStats = true;
+            var filters = {};
+            if (this.selectedCompany) filters.companyId = this.selectedCompany._id;
+            if (this.dateFrom) filters.dateFrom = this.dateFrom;
+            if (this.dateTo) filters.dateTo = this.dateTo;
+
+            AuditService.getFindingStatsByType(this.statsFormat, filters)
+            .then((response) => {
+                if (this.statsFormat === 'json') {
+                    var data = JSON.stringify(response.data.datas, null, 2);
+                    this.downloadFile(data, 'finding-statistics.json', 'application/json');
+                } else {
+                    var ext = this.statsFormat === 'yaml' ? 'yml' : 'csv';
+                    var type = this.statsFormat === 'yaml' ? 'application/yaml' : 'text/csv';
+                    this.downloadFile(response.data, `finding-statistics.${ext}`, type);
+                }
+                this.loadingStats = false;
+            })
+            .catch((err) => {
+                this.loadingStats = false;
+                Notify.create({
+                    message: err.response?.data?.datas || $t('msg.downloadStatsFailed'),
+                    color: 'negative',
+                    textColor: 'white',
+                    position: 'top-right'
+                });
+            });
+        },
+
+        downloadFile: function(data, filename, mimeType) {
+            var blob = new Blob([data], { type: mimeType });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            URL.revokeObjectURL(url);
+            document.body.removeChild(a);
         }
     }
 }

--- a/frontend/src/pages/data/dump/index.vue
+++ b/frontend/src/pages/data/dump/index.vue
@@ -74,9 +74,68 @@
                     <div class="text-h6">{{$t('nav.audits')}}</div>
                 </q-card-section>
                 <q-separator />
-                <q-card-section>
-                    TODO
-                </q-card-section>
+                <div v-if="userStore.isAllowed('data:stats')">
+                    <q-card-section>
+                        <div class="text-bold">{{$t('findingStatistics')}}</div>
+                    </q-card-section>
+                    <q-card-section>
+                        <div class="text-grey-8" v-html="$t('findingStatisticsInfo')"></div>
+                    </q-card-section>
+                    <q-card-section>
+                        <div class="row q-gutter-md items-end">
+                            <q-select
+                                v-model="statsFormat"
+                                :options="formatOptions"
+                                :label="$t('exportFormat')"
+                                emit-value
+                                map-options
+                                dense
+                                outlined
+                                style="min-width: 120px"
+                            />
+                            <q-select
+                                v-model="selectedCompany"
+                                :options="companies"
+                                :label="$t('company')"
+                                option-label="name"
+                                option-value="_id"
+                                clearable
+                                dense
+                                outlined
+                                style="min-width: 200px"
+                            />
+                            <q-input
+                                v-model="dateFrom"
+                                :label="$t('dateFrom')"
+                                type="date"
+                                dense
+                                outlined
+                                style="min-width: 150px"
+                            />
+                            <q-input
+                                v-model="dateTo"
+                                :label="$t('dateTo')"
+                                type="date"
+                                dense
+                                outlined
+                                style="min-width: 150px"
+                            />
+                            <q-btn
+                                :label="$t('downloadStatistics')"
+                                color="secondary"
+                                flat
+                                class="bg-secondary text-white"
+                                @click="downloadFindingStats"
+                                :loading="loadingStats"
+                            />
+                        </div>
+                    </q-card-section>
+                </div>
+                <div v-else>
+                    <q-card-section>
+                        <div class="text-grey-6">{{$t('noStatsPermission')}}</div>
+                    </q-card-section>
+                </div>
             </q-card>
         </div>
     </div>

--- a/frontend/src/services/audit.js
+++ b/frontend/src/services/audit.js
@@ -119,4 +119,15 @@ export default {
   updateComment: function(auditId, comment) {
     return api.put(`audits/${auditId}/comments/${comment._id}`, comment)
   },
+
+  getFindingStatsByType: function(format = 'json', filters = {}) {
+    var params = { format, ...filters };
+    if (format === 'yaml' || format === 'csv') {
+      return api.get('audits/stats/findings-by-type', {
+        params,
+        responseType: 'blob'
+      });
+    }
+    return api.get('audits/stats/findings-by-type', { params });
+  },
 }


### PR DESCRIPTION
Hi, many of managers usually seek for the feature to have a statistics on vulnerabilities by their severity and vulnerability types.
Statistics could be overall for a period for all companies, or related to a certain company for a given period (useful when it orders many audits). Supporting popular formats as yaml, json, csv.

Decided to create this one as pull request as we use this functionality in our team.

Hope to contribute more to this project later.

js-yaml dependency checked for being old enough and not having known CVEs, so pinned this version for now.
Graphical representation of a feature,I decided to place it in the empty part of the /data endpoint :)
<img width="1162" height="1031" alt="image" src="https://github.com/user-attachments/assets/1401a984-5872-4161-8b66-d53c784bfdb3" />


With regards.