### PR TITLE
Update installation docs and add pwndoc-cli reference

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,4 +1,5 @@
 - [Installation](installation.md)
+- [pwndoc-cli](pwndoc-cli.md)
 - [Data](data.md)
 - [Roles](roles.md)
 - [Vulnerabilities](vulnerabilities.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,106 +1,126 @@
 # Installation
 
-> PwnDoc uses 3 containers: the backend, the frontend and the database. 
+> PwnDoc uses 3 containers: the backend, the frontend and the database. All operations go through the `./pwndoc-cli` management tool.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose
+- Git
+
+## Setup
+
+```bash
+git clone https://github.com/pwndoc/pwndoc
+cd pwndoc
+```
 
 ## Production
 
-All 3 containers can be run at once using the docker-compose file in the root directory.
+!> For production usage make sure to change the SSL certificates in `backend/ssl/` and `frontend/ssl/`, and optionally set the JWT secrets in `backend/src/config/config.json` (`jwtSecret` and `jwtRefreshSecret`) if you don't want random ones generated.
 
-!> For production usage make sure to change the certificates in `backend/ssl` folder and optionally to set the JWT secret in `backend/src/lib/auth.js` (`jwtSecret` and `jwtRefreshSecret` in `backend/src/config/config.json`) if you don't want to use random ones.
-
-Build and run Docker containers
+Start containers (pulls pre-built images)
 
 ```
-docker-compose up -d --build
+./pwndoc-cli up
 ```
 
-Display backend container logs
+Application is accessible at https://localhost:8443  
+API is accessible at https://localhost:8443/api
+
+## Development
+
+> Source code can be modified live. The application reloads automatically on changes.
 
 ```
-docker-compose logs -f pwndoc-backend
+./pwndoc-cli up --dev
 ```
 
-Stop/Start containers
+Application is accessible at https://localhost:8081  
+API is accessible at https://localhost:8081/api
+
+## Build from Local Source
+
+To run with production config but built from local source:
 
 ```
-docker-compose stop
-docker-compose start
+./pwndoc-cli up --prod-local
+```
+
+## Common Operations
+
+Follow logs
+
+```
+./pwndoc-cli logs
+./pwndoc-cli logs --backend-only
+./pwndoc-cli logs --frontend-only
+```
+
+Container status
+
+```
+./pwndoc-cli ps
+```
+
+Stop / start / restart
+
+```
+./pwndoc-cli stop
+./pwndoc-cli start
+./pwndoc-cli restart
 ```
 
 Remove containers
 
 ```
-docker-compose down
+./pwndoc-cli down
 ```
 
 Update
 
 ```
-docker-compose down
-git pull
-docker-compose up -d --build
+./pwndoc-cli update
 ```
 
-Application is accessible through https://localhost:8443  
-API is accessible through https://localhost:8443/api
-## Development
+## LanguageTool (Spellcheck)
 
-For development purposes, specific docker-compose file can be used in each folder (backend/frontend).
-
-> *Source code can be modified live and application will automatically reload on changes.*
-
-Build and run backend and database containers
+LanguageTool is an optional spellcheck service. Start it alongside the main stack:
 
 ```
-docker-compose -f backend/docker-compose.dev.yml up -d --build
+./pwndoc-cli up --with-lt
 ```
 
-Display backend container logs
+Retrieve the API key once running:
 
 ```
-docker-compose -f backend/docker-compose.dev.yml logs -f pwndoc-backend
+./pwndoc-cli lt-apikey
 ```
 
-Stop/Start container
-
-```
-docker-compose -f backend/docker-compose.dev.yml stop
-docker-compose -f backend/docker-compose.dev.yml start
-```
-
-Remove containers
-
-```
-docker-compose -f backend/docker-compose.dev.yml down
-```
-
-Application is accessible through https://localhost:8081  
-API is accessible through https://localhost:8081/api
+Per-user spellcheck configuration is available in the application Settings page.
 
 ## Tests
 
-> For now only backend tests have been written (it's a continuous work in progress)
-
-Test files are located in `backend/tests` using Jest testing framework
-
-Script `run_tests.sh` at the root folder can be used to launch tests :
+Run all test suites
 
 ```
-Usage:        ./run_tests.sh -q|-f [-h, --help]
-
-Options:
-  -h, --help  Display help
-  -q          Run quick tests (No build)
-  -f          Run full tests (Build with no cache)
+./pwndoc-cli test
 ```
 
-!> **Don't use it in production as it will delete the production Database**
+Run specific suites
+
+```
+./pwndoc-cli test --backend         # Backend API tests (Jest)
+./pwndoc-cli test --frontend-unit   # Frontend unit tests (Vitest)
+./pwndoc-cli test --frontend-e2e    # E2E tests (Playwright, full stack)
+```
+
+See [pwndoc-cli](pwndoc-cli.md) for the full list of test options.
 
 ## Backup
 
-It's possible, even recommended, to regularly backup the `backend/mongo-data` folder. It contains all the database.
+It is recommended to regularly back up the `backend/mongo-data` folder. It contains the entire database.
 
-To restore :
+To restore:
 - Stop containers
-- Replace the current `backend/mongo-data` folder with the backed up one
+- Replace `backend/mongo-data` with the backed-up folder
 - Start containers

--- a/docs/pwndoc-cli.md
+++ b/docs/pwndoc-cli.md
@@ -1,0 +1,89 @@
+# pwndoc-cli
+
+`pwndoc-cli` is the management tool for all PwnDoc operations: starting environments, running tests, viewing logs, and updating the stack.
+
+```
+./pwndoc-cli <command> [options]
+```
+
+Enable tab completion:
+
+```
+source <(./pwndoc-cli completion)
+```
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `up` / `deploy` | Build, (re)create, and start containers |
+| `down` / `destroy` | Bring down and remove containers |
+| `build` | Build containers without starting |
+| `update` | Pull/build latest images and recreate containers |
+| `stop` | Stop containers |
+| `start` | Start containers |
+| `restart` | Restart containers |
+| `logs` | Follow container logs |
+| `ps` / `status` | Show container status |
+| `lt-apikey` | Print the LanguageTool API key |
+| `test` | Run tests |
+| `help` | Show help |
+
+## Environment Options
+
+The default environment is **prod** (pre-built images). No flag needed.
+
+| Flag | Environment |
+|---|---|
+| *(none)* | Production (pulls pre-built images) |
+| `--prod-local` | Production config, built from local source |
+| `--dev` | Development (hot-reload, source mounts) |
+
+## Targeting Options
+
+| Flag | Effect |
+|---|---|
+| `--backend-only` | Operate only on backend services |
+| `--frontend-only` | Operate only on frontend services |
+| `--with-lt` | Include the optional LanguageTool service |
+
+## Test Options
+
+| Flag | Description |
+|---|---|
+| `--backend` | Backend API tests (Jest) |
+| `--frontend-unit` | Frontend unit tests (Vitest, no browser) |
+| `--frontend-e2e` | E2E tests (Playwright, full stack) |
+| `--ui` | Playwright UI mode (implies `--frontend-e2e`) |
+| `--coverage` | Collect coverage (backend + frontend-unit) |
+| `--chromium` | E2E on Chromium only |
+| `--firefox` | E2E on Firefox only |
+| `--webkit` | E2E on WebKit only |
+
+Running `./pwndoc-cli test` with no flags runs all suites. Flags are combinable.
+
+## Examples
+
+```bash
+# Start environments
+./pwndoc-cli up
+./pwndoc-cli up --dev
+./pwndoc-cli up --with-lt
+
+# Logs and status
+./pwndoc-cli logs --backend-only
+./pwndoc-cli ps
+
+# Update
+./pwndoc-cli update
+./pwndoc-cli update --prod-local
+
+# Tests
+./pwndoc-cli test
+./pwndoc-cli test --backend
+./pwndoc-cli test --frontend-e2e --chromium --firefox
+./pwndoc-cli test --backend --frontend-unit --coverage
+
+# LanguageTool
+./pwndoc-cli lt-apikey
+```


### PR DESCRIPTION
- Addressing issue #654
The installation docs were referencing raw docker-compose commands that no longer work since pwndoc-cli was introduced in v1.4.0. This PR brings them up to date and adds a dedicated CLI reference page.          
                                                                                                                                                                                                                     
  Changes:                                                                                                                                                                                                           
  - docs/installation.md - Rewritten to use ./pwndoc-cli commands. Covers all three environments (prod, dev, prod-local), LanguageTool setup, updated test commands, and the update workflow. Removes all direct docker-compose references since these fail. 
  - docs/pwndoc-cli.md - New page with a full command and options reference for pwndoc-cli.
  - docs/_sidebar.md - Added pwndoc-cli link to the sidebar after Installation.