### PR TITLE
fix: backup images JSON files empty due to $unwind dropping documents with empty arrays

### DIFF
--- a/backend/src/models/audit.js
+++ b/backend/src/models/audit.js
@@ -1129,9 +1129,9 @@ AuditSchema.statics.getAuditsImages = (auditsIds = []) => {
             matchFilter['_id'] = {$in: auditsIds.map(e => new mongoose.Types.ObjectId(e))}
         var query = Audit.aggregate([{$match: matchFilter}])
         query.unwind({path: '$customFields', preserveNullAndEmptyArrays: true})
-        query.unwind('$sections')
-        query.unwind('$sections.customFields')
-        query.unwind('$findings')
+        query.unwind({path: '$sections', preserveNullAndEmptyArrays: true})
+        query.unwind({path: '$sections.customFields', preserveNullAndEmptyArrays: true})
+        query.unwind({path: '$findings', preserveNullAndEmptyArrays: true})
         query.unwind({path: '$findings.customFields', preserveNullAndEmptyArrays: true})
         query.addFields({
             imageFields: {

--- a/backend/src/models/vulnerability.js
+++ b/backend/src/models/vulnerability.js
@@ -251,7 +251,7 @@ VulnerabilitySchema.statics.getVulnsImages = (vulnsIds = []) => {
         if (vulnsIds.length > 0)
             matchFilter['_id'] = {$in: vulnsIds.map(e => new mongoose.Types.ObjectId(e))}
         var query = Vulnerability.aggregate([{$match: matchFilter}])
-        query.unwind('$details')
+        query.unwind({path: '$details', preserveNullAndEmptyArrays: true})
         query.unwind({path: '$details.customFields', preserveNullAndEmptyArrays: true})
         query.addFields({
             imageFields: {


### PR DESCRIPTION
When creating a backup, `audits-images.json` and `vulnerabilities-images.json` are always written as empty lists [], even when audits/vulnerabilities contain embedded images. The referenced Image documents are never exported.

The MongoDB aggregation pipelines in `getAuditsImages()` (Audit model)
https://github.com/pwndoc/pwndoc/blob/e68a578c0c2ee6574e5b6c3cdb54b4951395aa88/backend/src/models/audit.js#L1130-L1135
and `getVulnsImages()` (Vulnerability model)
https://github.com/pwndoc/pwndoc/blob/e68a578c0c2ee6574e5b6c3cdb54b4951395aa88/backend/src/models/vulnerability.js#L253-L255
use the shorthand form of `$unwind` on nested arrays without `preserveNullAndEmptyArrays: true`.

When any of these arrays is empty or missing, MongoDB drops the entire document from the pipeline, even if it matched the image regex filter via another field path and contains referenced images.

Example: An audit has images in `findings.description` but its sections array is empty (or sections have no `customFields`). The `$match` correctly finds it via `findings.description`, but `$unwind('$sections')` or `$unwind('$sections.customFields')` discards it before `$regexFindAll` can extract the image IDs. `getAuditsImages()` returns `[]`, and `Image.find({_id: {$in: []}})` matches nothing.