### PR TITLE
fix(audits): prevent severity to be undefined when score is zero

### DIFF
--- a/frontend/src/pages/audits/edit/index.vue
+++ b/frontend/src/pages/audits/edit/index.vue
@@ -657,7 +657,7 @@ export default {
 		},
 
 		getFindingSeverity: function(finding) {
-			let severity = "None"
+			let severity = null
 			let cvss = null
 
 			try {
@@ -684,6 +684,7 @@ export default {
 						severity = cvss.temporalSeverity
 				}
 			}
+			severity = severity || "None";
 			return severity.charAt(0).toUpperCase() + severity.slice(1).toLowerCase();
 		},
 


### PR DESCRIPTION
The `getFindingSeverity` function use a default of "None" for the `severity` variable, but it does not take into account that it can be overwritten with `undefined` when baseScore is 0.0, crashing the frontend when opening the audit edit page.

https://github.com/pwndoc/pwndoc/blob/e68a578c0c2ee6574e5b6c3cdb54b4951395aa88/frontend/src/pages/audits/edit/index.vue#L659-L687